### PR TITLE
feat(license): add search functionality for licenses in the license management page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "customer-portal",
       "version": "0.1.0",
+      "license": "GPL-3.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
         "@marsidev/react-turnstile": "^1.1.0",

--- a/src/app/session/license-keys/page.tsx
+++ b/src/app/session/license-keys/page.tsx
@@ -12,6 +12,8 @@ import { FilterControls } from "@/components/custom/filter-controls";
 import { DateRange } from "react-day-picker";
 import { selectBusiness } from "@/redux/slice/business/businessSlice";
 import { Key } from "@phosphor-icons/react";
+import { Input } from "@/components/ui/input";
+import { MagnifyingGlass } from "@phosphor-icons/react";
 
 
 const Page = () => {
@@ -24,6 +26,18 @@ const Page = () => {
   const [dateFilter, setDateFilter] = useState<DateRange | undefined>(
     undefined
   );
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [debouncedSearch, setDebouncedSearch] = useState<string>("");
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchQuery);
+      setPageNumber(0); // Reset to first page when search changes
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
 
   useEffect(() => {
     const fetchLicensesData = async () => {
@@ -34,12 +48,13 @@ const Page = () => {
         status: statusFilter[0],
         created_at_gte: dateFilter?.from,
         created_at_lte: dateFilter?.to,
+        search: debouncedSearch || undefined,
       };
       await dispatch(fetchLicenses(params));
       setIsLoading(false);
     };
     fetchLicensesData();
-  }, [dispatch, pageNumber, statusFilter, dateFilter]);
+  }, [dispatch, pageNumber, statusFilter, dateFilter, debouncedSearch]);
 
  
 
@@ -51,7 +66,7 @@ const Page = () => {
         </div>
       );
     }
-    if (licenses.data.length === 0 && !isLoading && !Boolean(dateFilter) && statusFilter.length === 0) {
+    if (licenses.data.length === 0 && !isLoading && !Boolean(dateFilter) && statusFilter.length === 0 && !debouncedSearch) {
       return (
         <div className="flex flex-col justify-center items-center min-h-[calc(100vh-20rem)]">
           <span className="text-text-primary p-3 mb-3 bg-bg-secondary rounded-full">
@@ -101,6 +116,18 @@ const Page = () => {
         }
       />
       <Separator className="my-6" />
+      <div className="mb-4">
+        <div className="relative max-w-sm">
+          <MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-tertiary" />
+          <Input
+            type="text"
+            placeholder="Search by license key or product ID..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-10"
+          />
+        </div>
+      </div>
       {renderContent()}
     </div>
   );

--- a/src/redux/slice/license/licenseSlice.ts
+++ b/src/redux/slice/license/licenseSlice.ts
@@ -38,12 +38,14 @@ export const fetchLicenses = createAsyncThunk(
       created_at_gte,
       created_at_lte,
       status,
+      search,
     }: {
       pageSize: number;
       pageNumber: number;
       created_at_gte?: Date;
       created_at_lte?: Date;
       status?: string;
+      search?: string;
     },
     { dispatch }
   ) => {
@@ -63,6 +65,7 @@ export const fetchLicenses = createAsyncThunk(
             created_at_gte,
             created_at_lte,
             status,
+            search,
           },
           headers: {
             Authorization: `Bearer ${tokenData.token}`,


### PR DESCRIPTION


## Summary

Adds a search input to the License Keys page, allowing users to filter license keys by key value or product ID. The search is debounced (300ms) for better UX and is integrated with existing filters and pagination. The Redux slice and API call now support a `search` parameter.

## Checklist

- [x] Follows project code style and conventions
- [ ] Updated tests (if applicable)
- [ ] Updated docs/README (if applicable)
- [x] No console errors/warnings

## Screenshots/Recordings

**Before:**  
License Keys page had only status/date filters, no search.
<img width="1151" height="598" alt="Screenshot (6)" src="https://github.com/user-attachments/assets/9d981902-8f53-436c-9828-4de795e9397a" />


**After:**  
- Search input with magnifying glass icon above the table.
- Typing a query filters license keys by key or product ID.
- Search works with status/date filters and resets pagination.

<img width="1344" height="545" alt="Screenshot (5)" src="https://github.com/user-attachments/assets/c6e5ced1-82af-4320-a9e5-c0f8507cadc8" />


*(Add screenshots or a short screen recording here if possible)*

## Related issues

Closes #36



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added search capability for license keys. Users can now easily search and filter their license keys to quickly find specific entries. The search input provides dynamic, real-time filtering as users type their search query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->