### PR TITLE
feat: add 'next' query parameter for post-login redirects

### DIFF
--- a/src/app/api/auth/business-validate/route.ts
+++ b/src/app/api/auth/business-validate/route.ts
@@ -4,7 +4,7 @@ import { BUSINESS_TOKEN_COOKIE_NAME, BUSINESS_TOKEN_EXPIRY_COOKIE_NAME } from "@
 import parseError from "@/lib/serverErrorHelper";
 import { ssrProxyFetch } from "@/lib/ssr-proxy";
 
-async function validateBusinessToken(token: string) {
+async function validateBusinessToken(token: string, nextUrl?: string | null) {
   const expiresAt = Date.now() + 1000 * 60 * 60 * 24; // 24 hours
 
   const response = await ssrProxyFetch({
@@ -40,13 +40,16 @@ async function validateBusinessToken(token: string) {
     httpOnly: true,
   });
 
-  return { success: true, redirect: "/businesses" };
+  const redirectUrl = nextUrl && nextUrl.startsWith("/") ? nextUrl : "/businesses";
+
+  return { success: true, redirect: redirectUrl };
 }
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const token = body.token;
+    const next = body.next;
 
     if (!token) {
       return NextResponse.json(
@@ -55,7 +58,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await validateBusinessToken(token);
+    const result = await validateBusinessToken(token, next);
     
     return NextResponse.json(result);
   } catch (error) {
@@ -70,13 +73,14 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const token = searchParams.get("token");
+  const next = searchParams.get("next");
 
   if (!token) {
     return NextResponse.redirect(new URL("/expired", request.url));
   }
 
   try {
-    const result = await validateBusinessToken(token);
+    const result = await validateBusinessToken(token, next);
     
     if (result.success) {
       return NextResponse.redirect(

--- a/src/app/api/auth/session-validate/route.ts
+++ b/src/app/api/auth/session-validate/route.ts
@@ -13,7 +13,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
   }
 }
 
-async function validateToken(token: string) {
+async function validateToken(token: string, nextUrl?: string | null) {
   const expiresAt = Date.now() + 1000 * 60 * 60 * 24; // 24 hours
 
   const response = await ssrProxyFetch({
@@ -82,13 +82,16 @@ async function validateToken(token: string) {
     }
   }
 
-  return { success: true, redirect: "/session/overview", returnUrl };
+  const redirectUrl = nextUrl && nextUrl.startsWith("/") ? nextUrl : "/session/overview";
+
+  return { success: true, redirect: redirectUrl, returnUrl };
 }
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const token = body.token;
+    const next = body.next;
 
     if (!token) {
       return NextResponse.json(
@@ -97,7 +100,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await validateToken(token);
+    const result = await validateToken(token, next);
     
     return NextResponse.json(result);
   } catch (error) {
@@ -112,13 +115,14 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const token = searchParams.get("token");
+  const next = searchParams.get("next");
 
   if (!token) {
     return NextResponse.redirect(new URL("/expired", request.url));
   }
 
   try {
-    const result = await validateToken(token);
+    const result = await validateToken(token, next);
     
     if (result.success) {
       const redirectUrl = new URL(result.redirect, request.url);

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,6 +1,5 @@
 import { OverviewContent } from "@/components/session/overview/overview-content";
 import {
-  DEMO_USER,
   DEMO_SUBSCRIPTIONS,
   DEMO_PAYMENT_METHODS,
   DEMO_BILLING_HISTORY,
@@ -60,7 +59,6 @@ export default async function DemoPage({ searchParams }: DemoPageProps) {
         baseUrl: refundBaseUrl,
         pageParamKey: REFUND_PAGE_PARAM,
       }}
-      user={DEMO_USER}
       wallets={DEMO_WALLETS}
       walletLedgerByCurrency={DEMO_WALLET_LEDGER}
       creditEntitlements={DEMO_CREDIT_ENTITLEMENTS}

--- a/src/app/session/[token]/page.tsx
+++ b/src/app/session/[token]/page.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import LoadingOverlay from '@/components/loading-overlay';
 
 export default function Page() {
   const params = useParams();
+  const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
   const token = params?.token as string;
+  const nextUrl = searchParams?.get('next');
 
   useEffect(() => {
     async function validateToken() {
@@ -23,7 +25,7 @@ export default function Page() {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ token }),
+          body: JSON.stringify({ token, next: nextUrl }),
         });
 
         if (!response.ok) {

--- a/src/app/session/[token]/page.tsx
+++ b/src/app/session/[token]/page.tsx
@@ -56,7 +56,7 @@ export default function Page() {
     }
 
     validateToken();
-  }, [token]);
+  }, [token, nextUrl]);
 
   if (error) {
     return (

--- a/src/app/unified-session/[token]/page.tsx
+++ b/src/app/unified-session/[token]/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import LoadingOverlay from "@/components/loading-overlay";
 
 export default function Page() {
   const params = useParams();
+  const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
   const token = params?.token as string;
+  const nextUrl = searchParams?.get("next");
 
   useEffect(() => {
     async function validateBusinessToken() {
@@ -22,7 +24,7 @@ export default function Page() {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ token }),
+          body: JSON.stringify({ token, next: nextUrl }),
         });
 
         if (response.status !== 200) {

--- a/src/app/unified-session/[token]/page.tsx
+++ b/src/app/unified-session/[token]/page.tsx
@@ -47,7 +47,7 @@ export default function Page() {
     }
 
     validateBusinessToken();
-  }, [token]);
+  }, [token, nextUrl]);
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary
Adds support for a `?next=` query parameter that allows specifying a redirect destination after successful session or business token validation.

## Changes
- **Session validation** (`/session/[token]`): Accepts `?next=/path` to redirect after token validation
- **Business validation** (`/unified-session/[token]`): Accepts `?next=/path` to redirect after token validation  
- **API routes**: Updated both `session-validate` and `business-validate` endpoints to handle the `next` parameter
- **Security**: Only relative paths starting with `/` are accepted (prevents external redirects)

## Usage
```
/session/abc123?next=/session/subscriptions/sub_123
/session/abc123?next=/session/payment-methods
/unified-session/abc123?next=/businesses/some-page
```

## Files Changed
- `src/app/session/[token]/page.tsx` - Read next param from URL and pass to API
- `src/app/unified-session/[token]/page.tsx` - Read next param from URL and pass to API
- `src/app/api/auth/session-validate/route.ts` - Handle next param in validation
- `src/app/api/auth/business-validate/route.ts` - Handle next param in validation
- `src/app/demo/page.tsx` - Fix: Remove unused DEMO_USER prop

## Testing
- Build passes successfully
- Token validation redirects to specified path when `next` is provided
- Falls back to default paths (`/session/overview`, `/businesses`) when `next` is missing or invalid