### PR TITLE
feat(entitlements): add entitlements page with new nested grant response shape

### DIFF
--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -63,6 +63,7 @@ export default async function DemoPage({ searchParams }: DemoPageProps) {
       walletLedgerByCurrency={DEMO_WALLET_LEDGER}
       creditEntitlements={DEMO_CREDIT_ENTITLEMENTS}
       creditLedgerByEntitlement={DEMO_CREDIT_LEDGER}
+      grants={[]}
       paginationBasePath="/demo"
     />
   );

--- a/src/app/session/entitlements/actions.ts
+++ b/src/app/session/entitlements/actions.ts
@@ -92,7 +92,7 @@ export async function fetchPortalEntitlements(): Promise<PortalGrantResponse[]> 
     }
 
     const data = await response.json();
-    console.log(data);
+    console.log(JSON.stringify(data, null, 2));
     return data.items || [];
   } catch (error) {
     parseError(error, "Failed to fetch entitlements");
@@ -148,11 +148,9 @@ export async function downloadEntitlementGrant(
   grantId: string
 ): Promise<DownloadResponse | null> {
   try {
-    console.log(`Downloading entitlement grant ${grantId}`);
     const response = await makeAuthenticatedRequest(
       `/customer-portal/entitlements/${grantId}/download`
     );
-    console.log(`Response: ${response.status}`);
     if (!response.ok) {
       throw new Error(`Failed to get download url: ${response.status}`);
     }

--- a/src/app/session/entitlements/actions.ts
+++ b/src/app/session/entitlements/actions.ts
@@ -1,0 +1,165 @@
+"use server";
+
+import { makeAuthenticatedRequest } from "@/lib/server-actions";
+import parseError from "@/lib/serverErrorHelper";
+
+export interface EntitlementSummary {
+  name: string;
+  integration_type: string;
+  description?: string | null;
+}
+
+export type EntitlementGrantStatus = "Pending" | "Delivered" | "Failed" | "Revoked";
+
+export type PortalGrantActionType = "oauth" | "telegram_connect" | "none";
+
+export interface GrantErrorInfo {
+  code: string;
+  message: string;
+}
+
+export interface DownloadFile {
+  file_id: string;
+  download_url: string;
+  filename: string;
+  expires_in: number;
+  content_type?: string | null;
+  file_size?: number | null;
+}
+
+export interface DownloadResponse {
+  files: DownloadFile[];
+  external_link?: string | null;
+  instructions?: string | null;
+}
+
+export interface LicenseKeyGrant {
+  key: string;
+  expires_at: string | null;
+  activations_used: number;
+  activations_limit: number | null;
+}
+
+export interface DigitalProductDeliveryFile {
+  file_id: string;
+  download_url: string;
+  filename: string;
+  expires_in: number;
+  content_type: string | null;
+  file_size: number | null;
+}
+
+export interface DigitalProductDelivery {
+  files: DigitalProductDeliveryFile[];
+  instructions: string | null;
+  external_url: string | null;
+}
+
+export interface PortalGrantResponse {
+  id: string;
+  entitlement: EntitlementSummary;
+  status: EntitlementGrantStatus;
+  requires_action: boolean;
+  action_type: PortalGrantActionType;
+  created_at: string;
+  updated_at: string;
+  delivered_at?: string | null;
+  oauth_expires_at?: string | null;
+  oauth_url?: string | null;
+  license_key: LicenseKeyGrant | null;
+  digital_product_delivery: DigitalProductDelivery | null;
+  error?: GrantErrorInfo | null;
+}
+
+export interface AcceptResponse {
+  status: EntitlementGrantStatus;
+  oauth_url?: string | null;
+  oauth_expires_at?: string | null;
+}
+
+export interface AcceptRequest {
+  return_to?: string | null;
+  metadata?: Record<string, string> | null;
+  telegram_user_id?: string | null;
+}
+
+export async function fetchPortalEntitlements(): Promise<PortalGrantResponse[]> {
+  try {
+    const response = await makeAuthenticatedRequest("/customer-portal/entitlements");
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch entitlements: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log(data);
+    return data.items || [];
+  } catch (error) {
+    parseError(error, "Failed to fetch entitlements");
+    return [];
+  }
+}
+
+export async function acceptEntitlementGrant(
+  grantId: string,
+  body: AcceptRequest = {},
+): Promise<AcceptResponse | null> {
+  try {
+    const response = await makeAuthenticatedRequest(
+      `/customer-portal/entitlements/${grantId}/accept`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to accept entitlement: ${response.status}`);
+    }
+
+    return (await response.json()) as AcceptResponse;
+  } catch (error) {
+    parseError(error, "Failed to accept entitlement");
+    return null;
+  }
+}
+
+export async function reconnectEntitlementGrant(
+  grantId: string,
+): Promise<AcceptResponse | null> {
+  try {
+    const response = await makeAuthenticatedRequest(
+      `/customer-portal/entitlements/${grantId}/reconnect`,
+      { method: "POST" },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to reconnect entitlement: ${response.status}`);
+    }
+
+    return (await response.json()) as AcceptResponse;
+  } catch (error) {
+    parseError(error, "Failed to reconnect entitlement");
+    return null;
+  }
+}
+
+export async function downloadEntitlementGrant(
+  grantId: string
+): Promise<DownloadResponse | null> {
+  try {
+    console.log(`Downloading entitlement grant ${grantId}`);
+    const response = await makeAuthenticatedRequest(
+      `/customer-portal/entitlements/${grantId}/download`
+    );
+    console.log(`Response: ${response.status}`);
+    if (!response.ok) {
+      throw new Error(`Failed to get download url: ${response.status}`);
+    }
+
+    return (await response.json()) as DownloadResponse;
+  } catch (error) {
+    parseError(error, "Failed to get download URL");
+    return null;
+  }
+}

--- a/src/app/session/overview/page.tsx
+++ b/src/app/session/overview/page.tsx
@@ -3,6 +3,7 @@ import { fetchSubscriptions } from "../subscriptions/actions";
 import { fetchPaymentMethods } from "../payment-methods/action";
 import { fetchPayments, fetchRefunds } from "../orders/actions";
 import { fetchWallets, fetchWalletLedger, fetchCreditEntitlements, fetchCreditEntitlementLedger } from "../profile/actions";
+import { fetchPortalEntitlements, type PortalGrantResponse } from "../entitlements/actions";
 import { OverviewContent } from "@/components/session/overview/overview-content";
 import { SubscriptionData } from "@/components/session/subscriptions/subscriptions";
 import { OrderData } from "@/components/session/orders/orders";
@@ -17,6 +18,7 @@ const getCachedPayments = cache(fetchPayments);
 const getCachedRefunds = cache(fetchRefunds);
 const getCachedWallets = cache(fetchWallets);
 const getCachedCreditEntitlements = cache(fetchCreditEntitlements);
+const getCachedPortalEntitlements = cache(fetchPortalEntitlements);
 
 export const dynamic = "force-dynamic";
 
@@ -100,7 +102,7 @@ export default async function OverviewPage({ searchParams }: OverviewPageProps) 
         return { creditEntitlements: items, creditLedgerByEntitlement: ledger };
     }
 
-    let subscriptionsData, paymentMethods, billingHistoryData, refundHistoryData, walletsResult, creditsResult;
+    let subscriptionsData, paymentMethods, billingHistoryData, refundHistoryData, walletsResult, creditsResult, entitlementsData;
 
     try {
         [
@@ -109,7 +111,8 @@ export default async function OverviewPage({ searchParams }: OverviewPageProps) 
             billingHistoryData,
             refundHistoryData,
             walletsResult,
-            creditsResult
+            creditsResult,
+            entitlementsData,
         ] = await Promise.all([
             getCachedSubscriptions(0, OVERVIEW_SUBSCRIPTIONS_SIZE),
             getCachedPaymentMethods(),
@@ -117,6 +120,7 @@ export default async function OverviewPage({ searchParams }: OverviewPageProps) 
             getCachedRefunds(refundPage, OVERVIEW_REFUND_PAGE_SIZE),
             fetchWalletsWithLedger(),
             fetchCreditsWithLedger(),
+            getCachedPortalEntitlements(),
         ]);
     } catch (error) {
         console.error("Failed to fetch overview data:", error);
@@ -126,6 +130,7 @@ export default async function OverviewPage({ searchParams }: OverviewPageProps) 
         refundHistoryData = { data: [], totalCount: 0, hasNext: false };
         walletsResult = { walletItems: [] as WalletItem[], walletLedgerByCurrency: {} as Record<string, WalletLedgerItem[]> };
         creditsResult = { creditEntitlements: [] as CreditEntitlementItem[], creditLedgerByEntitlement: {} as Record<string, CreditLedgerItem[]> };
+        entitlementsData = [] as PortalGrantResponse[];
     }
 
     const safePaymentMethods = (paymentMethods || []) as PaymentMethodItem[];
@@ -133,6 +138,7 @@ export default async function OverviewPage({ searchParams }: OverviewPageProps) 
     const walletLedgerByCurrency = walletsResult.walletLedgerByCurrency;
     const creditEntitlements = creditsResult.creditEntitlements;
     const creditLedgerByEntitlement = creditsResult.creditLedgerByEntitlement;
+    const grants = (entitlementsData || []);
 
     return (
         <OverviewContent
@@ -159,6 +165,7 @@ export default async function OverviewPage({ searchParams }: OverviewPageProps) 
             walletLedgerByCurrency={walletLedgerByCurrency}
             creditEntitlements={creditEntitlements}
             creditLedgerByEntitlement={creditLedgerByEntitlement}
+            grants={grants}
         />
     );
 }

--- a/src/components/session/entitlements/entitlements-columns.tsx
+++ b/src/components/session/entitlements/entitlements-columns.tsx
@@ -189,6 +189,20 @@ function GrantDetailSheet({
                         </div>
                     )}
 
+                    {grant.status === "Delivered" && grant.oauth_url && (
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm text-text-secondary">OAuth connection</span>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => window.open(grant.oauth_url!, "_blank", "noopener,noreferrer")}
+                            >
+                                <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                                Reconnect
+                            </Button>
+                        </div>
+                    )}
+
                     {isDigitalFiles && grant.status !== "Delivered" && (
                         <p className="text-sm text-text-secondary">
                             Files will be available once the entitlement is delivered.

--- a/src/components/session/entitlements/entitlements-columns.tsx
+++ b/src/components/session/entitlements/entitlements-columns.tsx
@@ -68,6 +68,179 @@ function statusBadgeVariant(status: PortalGrantResponse["status"]): BadgeVariant
     }
 }
 
+function ActionCell({ raw }: { raw: PortalGrantResponse }) {
+    const router = useRouter();
+    const [viewOpen, setViewOpen] = useState(false);
+    const [connecting, setConnecting] = useState(false);
+    const [reconnecting, setReconnecting] = useState(false);
+    const [telegramOpen, setTelegramOpen] = useState(false);
+    const [telegramUserId, setTelegramUserId] = useState("");
+    const [telegramSubmitting, setTelegramSubmitting] = useState(false);
+
+    const handleOAuthConnect = async () => {
+        setConnecting(true);
+        const res = await acceptEntitlementGrant(raw.id, {
+            return_to: typeof window !== "undefined" ? window.location.href : undefined,
+        });
+        setConnecting(false);
+        if (res?.oauth_url) {
+            window.open(res.oauth_url, "_blank", "noopener,noreferrer");
+            router.refresh();
+        } else {
+            toast.error("No authorization URL returned");
+        }
+    };
+
+    const handleTelegramSubmit = async () => {
+        const trimmed = telegramUserId.trim();
+        if (!trimmed) {
+            toast.error("Telegram user ID is required");
+            return;
+        }
+        setTelegramSubmitting(true);
+        const res = await acceptEntitlementGrant(raw.id, {
+            telegram_user_id: trimmed,
+        });
+        setTelegramSubmitting(false);
+        if (res) {
+            toast.success("Telegram account linked");
+            setTelegramOpen(false);
+            setTelegramUserId("");
+            router.refresh();
+        } else {
+            toast.error("Failed to link Telegram account");
+        }
+    };
+
+    const handleReconnect = async () => {
+        setReconnecting(true);
+        const res = await reconnectEntitlementGrant(raw.id);
+        setReconnecting(false);
+        if (res?.oauth_url) {
+            window.open(res.oauth_url, "_blank", "noopener,noreferrer");
+            router.refresh();
+        } else if (res) {
+            toast.success("Reconnected successfully");
+            router.refresh();
+        } else {
+            toast.error("Failed to reconnect");
+        }
+    };
+
+    const isPendingOAuth =
+        raw.status === "Pending" && raw.requires_action && raw.action_type === "oauth";
+    const isPendingTelegram =
+        raw.status === "Pending" && raw.requires_action && raw.action_type === "telegram_connect";
+    const isExpiredOAuth =
+        raw.status === "Delivered" && raw.oauth_expires_at && new Date(raw.oauth_expires_at) < new Date();
+
+    return (
+        <>
+            <div className="flex justify-end gap-2">
+                {isPendingOAuth && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleOAuthConnect}
+                        disabled={connecting}
+                    >
+                        {connecting ? (
+                            <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />
+                        ) : (
+                            <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                        )}
+                        Connect
+                    </Button>
+                )}
+
+                {isPendingTelegram && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setTelegramOpen(true)}
+                    >
+                        <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                        Connect
+                    </Button>
+                )}
+
+                {isExpiredOAuth && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleReconnect}
+                        disabled={reconnecting}
+                    >
+                        {reconnecting ? (
+                            <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />
+                        ) : (
+                            <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                        )}
+                        Reconnect
+                    </Button>
+                )}
+
+                {!isPendingOAuth && !isPendingTelegram && !isExpiredOAuth && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setViewOpen(true)}
+                    >
+                        {raw.entitlement.integration_type === "license_key" ? (
+                            <KeyRound className="w-3.5 h-3.5 mr-1.5" />
+                        ) : (
+                            <Eye className="w-3.5 h-3.5 mr-1.5" />
+                        )}
+                        View
+                    </Button>
+                )}
+            </div>
+            <GrantDetailSheet
+                grant={raw}
+                open={viewOpen}
+                onOpenChange={setViewOpen}
+            />
+            <Dialog open={telegramOpen} onOpenChange={setTelegramOpen}>
+                <DialogContent className="sm:max-w-md">
+                    <DialogHeader>
+                        <DialogTitle>Connect Telegram</DialogTitle>
+                        <DialogDescription>
+                            Enter your Telegram user ID to link your account to this entitlement.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="flex flex-col gap-2 py-2">
+                        <Label htmlFor={`telegram-${raw.id}`}>Telegram user ID</Label>
+                        <Input
+                            id={`telegram-${raw.id}`}
+                            placeholder="e.g. 123456789"
+                            value={telegramUserId}
+                            onChange={(e) => setTelegramUserId(e.target.value)}
+                        />
+                    </div>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setTelegramOpen(false)}
+                            disabled={telegramSubmitting}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            onClick={handleTelegramSubmit}
+                            disabled={telegramSubmitting || !telegramUserId.trim()}
+                        >
+                            {telegramSubmitting && (
+                                <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                            )}
+                            Link account
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}
+
 function statusLabel(status: PortalGrantResponse["status"]): string {
     switch (status) {
         case "Delivered":
@@ -348,178 +521,6 @@ export const EntitlementsColumns: ColumnDef<EntitlementRow>[] = [
     {
         id: "action",
         header: () => <div className="text-right">Action</div>,
-        cell: ({ row }) => {
-            const raw = row.original.raw;
-            const router = useRouter();
-            const [viewOpen, setViewOpen] = useState(false);
-            const [connecting, setConnecting] = useState(false);
-            const [reconnecting, setReconnecting] = useState(false);
-            const [telegramOpen, setTelegramOpen] = useState(false);
-            const [telegramUserId, setTelegramUserId] = useState("");
-            const [telegramSubmitting, setTelegramSubmitting] = useState(false);
-
-            const handleOAuthConnect = async () => {
-                setConnecting(true);
-                const res = await acceptEntitlementGrant(raw.id, {
-                    return_to: typeof window !== "undefined" ? window.location.href : undefined,
-                });
-                setConnecting(false);
-                if (res?.oauth_url) {
-                    window.open(res.oauth_url, "_blank", "noopener,noreferrer");
-                    router.refresh();
-                } else {
-                    toast.error("No authorization URL returned");
-                }
-            };
-
-            const handleTelegramSubmit = async () => {
-                const trimmed = telegramUserId.trim();
-                if (!trimmed) {
-                    toast.error("Telegram user ID is required");
-                    return;
-                }
-                setTelegramSubmitting(true);
-                const res = await acceptEntitlementGrant(raw.id, {
-                    telegram_user_id: trimmed,
-                });
-                setTelegramSubmitting(false);
-                if (res) {
-                    toast.success("Telegram account linked");
-                    setTelegramOpen(false);
-                    setTelegramUserId("");
-                    router.refresh();
-                } else {
-                    toast.error("Failed to link Telegram account");
-                }
-            };
-
-            const handleReconnect = async () => {
-                setReconnecting(true);
-                const res = await reconnectEntitlementGrant(raw.id);
-                setReconnecting(false);
-                if (res?.oauth_url) {
-                    window.open(res.oauth_url, "_blank", "noopener,noreferrer");
-                    router.refresh();
-                } else if (res) {
-                    toast.success("Reconnected successfully");
-                    router.refresh();
-                } else {
-                    toast.error("Failed to reconnect");
-                }
-            };
-
-            const isPendingOAuth =
-                raw.status === "Pending" && raw.requires_action && raw.action_type === "oauth";
-            const isPendingTelegram =
-                raw.status === "Pending" && raw.requires_action && raw.action_type === "telegram_connect";
-            const isExpiredOAuth =
-                raw.status === "Delivered" && raw.oauth_expires_at && new Date(raw.oauth_expires_at) < new Date();
-
-            return (
-                <>
-                    <div className="flex justify-end gap-2">
-                        {isPendingOAuth && (
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={handleOAuthConnect}
-                                disabled={connecting}
-                            >
-                                {connecting ? (
-                                    <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />
-                                ) : (
-                                    <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
-                                )}
-                                Connect
-                            </Button>
-                        )}
-
-                        {isPendingTelegram && (
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => setTelegramOpen(true)}
-                            >
-                                <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
-                                Connect
-                            </Button>
-                        )}
-
-                        {isExpiredOAuth && (
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={handleReconnect}
-                                disabled={reconnecting}
-                            >
-                                {reconnecting ? (
-                                    <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />
-                                ) : (
-                                    <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
-                                )}
-                                Reconnect
-                            </Button>
-                        )}
-
-                        {!isPendingOAuth && !isPendingTelegram && !isExpiredOAuth && (
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => setViewOpen(true)}
-                            >
-                                {raw.entitlement.integration_type === "license_key" ? (
-                                    <KeyRound className="w-3.5 h-3.5 mr-1.5" />
-                                ) : (
-                                    <Eye className="w-3.5 h-3.5 mr-1.5" />
-                                )}
-                                View
-                            </Button>
-                        )}
-                    </div>
-                    <GrantDetailSheet
-                        grant={raw}
-                        open={viewOpen}
-                        onOpenChange={setViewOpen}
-                    />
-                    <Dialog open={telegramOpen} onOpenChange={setTelegramOpen}>
-                        <DialogContent className="sm:max-w-md">
-                            <DialogHeader>
-                                <DialogTitle>Connect Telegram</DialogTitle>
-                                <DialogDescription>
-                                    Enter your Telegram user ID to link your account to this entitlement.
-                                </DialogDescription>
-                            </DialogHeader>
-                            <div className="flex flex-col gap-2 py-2">
-                                <Label htmlFor={`telegram-${raw.id}`}>Telegram user ID</Label>
-                                <Input
-                                    id={`telegram-${raw.id}`}
-                                    placeholder="e.g. 123456789"
-                                    value={telegramUserId}
-                                    onChange={(e) => setTelegramUserId(e.target.value)}
-                                />
-                            </div>
-                            <DialogFooter>
-                                <Button
-                                    variant="outline"
-                                    onClick={() => setTelegramOpen(false)}
-                                    disabled={telegramSubmitting}
-                                >
-                                    Cancel
-                                </Button>
-                                <Button
-                                    onClick={handleTelegramSubmit}
-                                    disabled={telegramSubmitting || !telegramUserId.trim()}
-                                >
-                                    {telegramSubmitting && (
-                                        <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                                    )}
-                                    Link account
-                                </Button>
-                            </DialogFooter>
-                        </DialogContent>
-                    </Dialog>
-                </>
-            );
-        },
+        cell: ({ row }) => <ActionCell raw={row.original.raw} />,
     },
 ];

--- a/src/components/session/entitlements/entitlements-columns.tsx
+++ b/src/components/session/entitlements/entitlements-columns.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ColumnDef } from "@tanstack/react-table";
+import { Badge, type BadgeVariant } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TimeTooltip } from "@/components/custom/time-tooltip";
+import { parseIsoDate } from "@/lib/date-helper";
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+} from "@/components/ui/sheet";
+import { Separator } from "@/components/ui/separator";
+import {
+    type PortalGrantResponse,
+    reconnectEntitlementGrant,
+    acceptEntitlementGrant,
+} from "@/app/session/entitlements/actions";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { Eye, EyeOff, Download, Loader2, ExternalLink, KeyRound, FileMinus } from "lucide-react";
+
+export interface EntitlementRow {
+    id: string;
+    name: string;
+    type: string;
+    date_accessed: string;
+    status: "active" | "inactive";
+    raw: PortalGrantResponse;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+    discord: "Discord Access",
+    github: "GitHub Access",
+    figma: "Figma Template",
+    notion: "Notion Template",
+    telegram: "Telegram Access",
+    framer: "Framer Template",
+    digital_files: "Digital Product Delivery",
+    license_key: "License Key",
+};
+
+function statusBadgeVariant(status: PortalGrantResponse["status"]): BadgeVariant {
+    switch (status) {
+        case "Delivered":
+            return "green";
+        case "Pending":
+            return "yellow";
+        case "Failed":
+            return "red";
+        case "Revoked":
+            return "default";
+        default:
+            return "default";
+    }
+}
+
+function statusLabel(status: PortalGrantResponse["status"]): string {
+    switch (status) {
+        case "Delivered":
+            return "Delivered";
+        case "Pending":
+            return "Pending";
+        case "Failed":
+            return "Failed";
+        case "Revoked":
+            return "Revoked";
+        default:
+            return status;
+    }
+}
+
+function GrantDetailSheet({
+    grant,
+    open,
+    onOpenChange,
+}: {
+    grant: PortalGrantResponse | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [visible, setVisible] = useState(false);
+
+    const isLicenseKey = grant?.entitlement.integration_type === "license_key";
+    const isDigitalFiles = grant?.entitlement.integration_type === "digital_files";
+
+    useEffect(() => {
+        if (!open) setVisible(false);
+    }, [open]);
+
+    if (!grant) return null;
+
+    const hasError = grant.error;
+    const dpd = grant.digital_product_delivery;
+    const hasDeliverable =
+        dpd &&
+        (dpd.files.length > 0 ||
+            !!dpd.external_url ||
+            !!dpd.instructions);
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent
+                className="sm:max-w-md mx-auto border-border-secondary rounded-xl border m-6"
+                floating
+                side="right"
+            >
+                <SheetHeader>
+                    <SheetTitle>{grant.entitlement.name}</SheetTitle>
+                    <SheetDescription>
+                        {TYPE_LABELS[grant.entitlement.integration_type] || grant.entitlement.integration_type}
+                    </SheetDescription>
+                </SheetHeader>
+                <Separator className="my-4" />
+                <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                        <span className="text-sm text-text-secondary">Status</span>
+                        <Badge variant={statusBadgeVariant(grant.status)} dot={false}>
+                            {statusLabel(grant.status)}
+                        </Badge>
+                    </div>
+
+                    {grant.delivered_at && (
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm text-text-secondary">Delivered</span>
+                            <span className="text-sm text-text-primary">
+                                {parseIsoDate(grant.delivered_at)}
+                            </span>
+                        </div>
+                    )}
+
+                    {grant.created_at && (
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm text-text-secondary">Created</span>
+                            <span className="text-sm text-text-primary">
+                                {parseIsoDate(grant.created_at)}
+                            </span>
+                        </div>
+                    )}
+
+                    {isLicenseKey && grant.status !== "Delivered" && (
+                        <p className="text-sm text-text-secondary">
+                            License key will be available once the entitlement is delivered.
+                        </p>
+                    )}
+
+                    {isLicenseKey && grant.status === "Delivered" && grant.license_key && (
+                        <div className="space-y-2">
+                            <span className="text-sm text-text-secondary">License Key</span>
+                            <div className="flex items-center justify-between rounded-lg border bg-card px-4 py-3">
+                                <p className="text-sm font-medium">
+                                    {visible ? (
+                                        <span className="font-mono text-text-primary">
+                                            {grant.license_key.key}
+                                        </span>
+                                    ) : (
+                                        <span className="italic text-text-secondary">
+                                            Click to view license key
+                                        </span>
+                                    )}
+                                </p>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="text-text-secondary"
+                                    onClick={() => setVisible((v) => !v)}
+                                >
+                                    {visible ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                                </Button>
+                            </div>
+                            {grant.license_key.expires_at && (
+                                <p className="text-xs text-text-secondary">
+                                    Expires {parseIsoDate(grant.license_key.expires_at)}
+                                </p>
+                            )}
+                        </div>
+                    )}
+
+                    {isDigitalFiles && grant.status !== "Delivered" && (
+                        <p className="text-sm text-text-secondary">
+                            Files will be available once the entitlement is delivered.
+                        </p>
+                    )}
+
+                    {isDigitalFiles && grant.status === "Delivered" && (
+                        <div className="space-y-3">
+                            {dpd && (
+                                <div className="space-y-3">
+                                    {dpd.files.length > 0 && (
+                                        <div className="space-y-2">
+                                            <h4 className="text-sm font-medium">Files</h4>
+                                            {dpd.files.map((file) => (
+                                                <div
+                                                    key={file.file_id}
+                                                    className="flex items-center justify-between p-2 border rounded"
+                                                >
+                                                    <div className="flex items-center gap-2 min-w-0">
+                                                        <FileMinus className="w-4 h-4 shrink-0" />
+                                                        <span className="text-sm truncate">{file.filename}</span>
+                                                    </div>
+                                                    <Button
+                                                        variant="outline"
+                                                        size="sm"
+                                                        onClick={() => window.open(file.download_url, "_blank", "noopener,noreferrer")}
+                                                    >
+                                                        <Download className="w-4 h-4" />
+                                                    </Button>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
+
+                                    {dpd.external_url && (
+                                        <Button
+                                            variant="secondary"
+                                            className="w-full"
+                                            onClick={() => window.open(dpd.external_url!, "_blank", "noopener,noreferrer")}
+                                        >
+                                            <ExternalLink className="w-4 h-4 mr-2" />
+                                            Open external link
+                                        </Button>
+                                    )}
+
+                                    {dpd.instructions && (
+                                        <div>
+                                            <h4 className="text-sm font-medium mb-1">Instructions</h4>
+                                            <p className="text-sm text-text-secondary whitespace-pre-line">
+                                                {dpd.instructions}
+                                            </p>
+                                        </div>
+                                    )}
+
+                                    {!hasDeliverable && (
+                                        <p className="text-sm text-text-secondary">
+                                            No files available.
+                                        </p>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {hasError && (
+                        <div className="rounded-lg border border-red-200 bg-red-50 dark:bg-red-950/30 p-3">
+                            <p className="text-sm font-medium text-red-800 dark:text-red-300">
+                                Error: {hasError.code}
+                            </p>
+                            <p className="text-sm text-red-700 dark:text-red-400 mt-1">
+                                {hasError.message}
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+export const EntitlementsColumns: ColumnDef<EntitlementRow>[] = [
+    {
+        id: "name",
+        accessorKey: "name",
+        header: "Name",
+        cell: ({ row }) => {
+            return (
+                <span className="text-sm text-text-primary font-medium">
+                    {row.original.name}
+                </span>
+            );
+        },
+    },
+    {
+        id: "type",
+        accessorKey: "type",
+        header: "Type",
+        cell: ({ row }) => {
+            const label =
+                TYPE_LABELS[row.original.type] || row.original.type;
+            return (
+                <Badge
+                    variant="default"
+                    dot={false}
+                    className="rounded-sm text-xs"
+                >
+                    {label}
+                </Badge>
+            );
+        },
+    },
+    {
+        id: "date_accessed",
+        accessorKey: "date_accessed",
+        header: "Date Accessed",
+        cell: ({ row }) => {
+            return (
+                <TimeTooltip
+                    timeStamp={row.original.date_accessed}
+                    className="text-sm text-text-primary font-medium"
+                    triggerFormat="shortDate"
+                />
+            );
+        },
+    },
+    {
+        id: "status",
+        accessorKey: "status",
+        header: "Status",
+        cell: ({ row }) => {
+            const raw = row.original.raw;
+            return (
+                <Badge
+                    variant={statusBadgeVariant(raw.status)}
+                    dot={false}
+                    className="rounded-sm text-xs"
+                >
+                    {statusLabel(raw.status)}
+                </Badge>
+            );
+        },
+    },
+    {
+        id: "action",
+        header: () => <div className="text-right">Action</div>,
+        cell: ({ row }) => {
+            const raw = row.original.raw;
+            const router = useRouter();
+            const [viewOpen, setViewOpen] = useState(false);
+            const [connecting, setConnecting] = useState(false);
+            const [reconnecting, setReconnecting] = useState(false);
+            const [telegramOpen, setTelegramOpen] = useState(false);
+            const [telegramUserId, setTelegramUserId] = useState("");
+            const [telegramSubmitting, setTelegramSubmitting] = useState(false);
+
+            const handleOAuthConnect = async () => {
+                setConnecting(true);
+                const res = await acceptEntitlementGrant(raw.id, {
+                    return_to: typeof window !== "undefined" ? window.location.href : undefined,
+                });
+                setConnecting(false);
+                if (res?.oauth_url) {
+                    window.open(res.oauth_url, "_blank", "noopener,noreferrer");
+                    router.refresh();
+                } else {
+                    toast.error("No authorization URL returned");
+                }
+            };
+
+            const handleTelegramSubmit = async () => {
+                const trimmed = telegramUserId.trim();
+                if (!trimmed) {
+                    toast.error("Telegram user ID is required");
+                    return;
+                }
+                setTelegramSubmitting(true);
+                const res = await acceptEntitlementGrant(raw.id, {
+                    telegram_user_id: trimmed,
+                });
+                setTelegramSubmitting(false);
+                if (res) {
+                    toast.success("Telegram account linked");
+                    setTelegramOpen(false);
+                    setTelegramUserId("");
+                    router.refresh();
+                } else {
+                    toast.error("Failed to link Telegram account");
+                }
+            };
+
+            const handleReconnect = async () => {
+                setReconnecting(true);
+                const res = await reconnectEntitlementGrant(raw.id);
+                setReconnecting(false);
+                if (res?.oauth_url) {
+                    window.open(res.oauth_url, "_blank", "noopener,noreferrer");
+                    router.refresh();
+                } else if (res) {
+                    toast.success("Reconnected successfully");
+                    router.refresh();
+                } else {
+                    toast.error("Failed to reconnect");
+                }
+            };
+
+            const isPendingOAuth =
+                raw.status === "Pending" && raw.requires_action && raw.action_type === "oauth";
+            const isPendingTelegram =
+                raw.status === "Pending" && raw.requires_action && raw.action_type === "telegram_connect";
+            const isExpiredOAuth =
+                raw.status === "Delivered" && raw.oauth_expires_at && new Date(raw.oauth_expires_at) < new Date();
+
+            return (
+                <>
+                    <div className="flex justify-end gap-2">
+                        {isPendingOAuth && (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={handleOAuthConnect}
+                                disabled={connecting}
+                            >
+                                {connecting ? (
+                                    <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />
+                                ) : (
+                                    <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                                )}
+                                Connect
+                            </Button>
+                        )}
+
+                        {isPendingTelegram && (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setTelegramOpen(true)}
+                            >
+                                <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                                Connect
+                            </Button>
+                        )}
+
+                        {isExpiredOAuth && (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={handleReconnect}
+                                disabled={reconnecting}
+                            >
+                                {reconnecting ? (
+                                    <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />
+                                ) : (
+                                    <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                                )}
+                                Reconnect
+                            </Button>
+                        )}
+
+                        {!isPendingOAuth && !isPendingTelegram && !isExpiredOAuth && (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setViewOpen(true)}
+                            >
+                                {raw.entitlement.integration_type === "license_key" ? (
+                                    <KeyRound className="w-3.5 h-3.5 mr-1.5" />
+                                ) : (
+                                    <Eye className="w-3.5 h-3.5 mr-1.5" />
+                                )}
+                                View
+                            </Button>
+                        )}
+                    </div>
+                    <GrantDetailSheet
+                        grant={raw}
+                        open={viewOpen}
+                        onOpenChange={setViewOpen}
+                    />
+                    <Dialog open={telegramOpen} onOpenChange={setTelegramOpen}>
+                        <DialogContent className="sm:max-w-md">
+                            <DialogHeader>
+                                <DialogTitle>Connect Telegram</DialogTitle>
+                                <DialogDescription>
+                                    Enter your Telegram user ID to link your account to this entitlement.
+                                </DialogDescription>
+                            </DialogHeader>
+                            <div className="flex flex-col gap-2 py-2">
+                                <Label htmlFor={`telegram-${raw.id}`}>Telegram user ID</Label>
+                                <Input
+                                    id={`telegram-${raw.id}`}
+                                    placeholder="e.g. 123456789"
+                                    value={telegramUserId}
+                                    onChange={(e) => setTelegramUserId(e.target.value)}
+                                />
+                            </div>
+                            <DialogFooter>
+                                <Button
+                                    variant="outline"
+                                    onClick={() => setTelegramOpen(false)}
+                                    disabled={telegramSubmitting}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    onClick={handleTelegramSubmit}
+                                    disabled={telegramSubmitting || !telegramUserId.trim()}
+                                >
+                                    {telegramSubmitting && (
+                                        <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                                    )}
+                                    Link account
+                                </Button>
+                            </DialogFooter>
+                        </DialogContent>
+                    </Dialog>
+                </>
+            );
+        },
+    },
+];

--- a/src/components/session/entitlements/entitlements-table.tsx
+++ b/src/components/session/entitlements/entitlements-table.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { CircleSlash } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { BaseDataGrid } from "@/components/table/BaseDataGrid";
+import {
+    EntitlementsColumns,
+    type EntitlementRow,
+} from "./entitlements-columns";
+import type { PortalGrantResponse } from "@/app/session/entitlements/actions";
+
+const PAGE_SIZE = 25;
+
+function mapGrantToRow(grant: PortalGrantResponse): EntitlementRow {
+    return {
+        id: grant.id,
+        name: grant.entitlement.name,
+        type: grant.entitlement.integration_type,
+        date_accessed: grant.delivered_at || grant.created_at,
+        status: grant.status === "Delivered" ? "active" : "inactive",
+        raw: grant,
+    };
+}
+
+interface EntitlementsTableProps {
+    grants: PortalGrantResponse[];
+}
+
+export function EntitlementsTable({ grants }: EntitlementsTableProps) {
+    const data = grants.map(mapGrantToRow);
+    const isEmpty = data.length === 0;
+
+    return (
+        <section id="entitlements">
+            <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-display font-medium text-text-primary">
+                    Entitlements
+                </h2>
+            </div>
+
+            {isEmpty ? (
+                <Card>
+                    <CardContent className="p-0">
+                        <div className="flex flex-col items-center justify-center py-12 text-center">
+                            <div className="p-4 bg-bg-secondary rounded-full mb-4">
+                                <CircleSlash className="w-6 h-6 text-text-secondary" />
+                            </div>
+                            <p className="text-text-secondary text-sm">
+                                No entitlements available
+                            </p>
+                        </div>
+                    </CardContent>
+                </Card>
+            ) : (
+                <BaseDataGrid
+                    tableId="entitlements-overview"
+                    data={data}
+                    columns={EntitlementsColumns}
+                    manualPagination
+                    initialPageSize={PAGE_SIZE}
+                    tableLayout={{
+                        autoWidth: false,
+                        columnsPinnable: false,
+                        columnsResizable: false,
+                        columnsMovable: false,
+                        columnsVisibility: false,
+                        disableRowPerPage: true,
+                    }}
+                    disablePagination={data.length <= PAGE_SIZE}
+                    emptyStateMessage="No entitlements available"
+                />
+            )}
+        </section>
+    );
+}

--- a/src/components/session/orders/billing-history-columns.tsx
+++ b/src/components/session/orders/billing-history-columns.tsx
@@ -6,7 +6,6 @@ import { getBadge } from "@/lib/badge-helper";
 import InvoiceDownloadSheet from "../invoice-download-sheet";
 import { api_url } from "@/lib/http";
 import { OrderData } from "./orders";
-import { EntitlementsCell } from "./entitlements-cell";
 import { TimeTooltip } from "@/components/custom/time-tooltip";
 import { CurrencyCode, decodeCurrency, formatCurrency } from "@/lib/currency-helper";
 
@@ -79,20 +78,6 @@ export function getBillingHistoryColumns(
                 >
                     {tBadge(badge.messageKey)}
                 </Badge>
-            );
-        },
-    },
-    {
-        id: "entitlements",
-        accessorKey: "digital_products_delivered",
-        header: t("entitlements"),
-        cell: ({ row }) => {
-            return (
-                <EntitlementsCell
-                    paymentId={row.original.payment_id}
-                    hasDigitalProducts={row.original.digital_products_delivered}
-                    hasLicenseKeys={row.original.has_license_key}
-                />
             );
         },
     },

--- a/src/components/session/overview/overview-content.tsx
+++ b/src/components/session/overview/overview-content.tsx
@@ -12,6 +12,8 @@ import { useCallback } from "react";
 import { RefundResponse } from "../refunds-column";
 import { RefundsTable } from "../refunds-table";
 import { SessionPageLayout } from "../session-page-layout";
+import { EntitlementsTable } from "../entitlements/entitlements-table";
+import type { PortalGrantResponse } from "@/app/session/entitlements/actions";
 
 interface BillingHistoryPagination {
     currentPage: number;
@@ -41,6 +43,7 @@ interface OverviewContentProps {
     walletLedgerByCurrency: Record<string, WalletLedgerItem[]>;
     creditEntitlements: CreditEntitlementItem[];
     creditLedgerByEntitlement: Record<string, CreditLedgerItem[]>;
+    grants: PortalGrantResponse[];
     /** Base path for billing history pagination (default: /session/overview) */
     paginationBasePath?: string;
 }
@@ -63,6 +66,7 @@ export function OverviewContent({
     walletLedgerByCurrency,
     creditEntitlements,
     creditLedgerByEntitlement,
+    grants,
     paginationBasePath = DEFAULT_PAGINATION_BASE_PATH,
 }: OverviewContentProps) {
     const router = useRouter();
@@ -112,6 +116,9 @@ export function OverviewContent({
                         entitlements={creditEntitlements}
                         creditLedgerByEntitlement={creditLedgerByEntitlement}
                     />
+                )}
+                {grants.length > 0 && (
+                    <EntitlementsTable grants={grants} />
                 )}
                 <Orders
                     ordersData={billingHistory}


### PR DESCRIPTION
## Summary

- Add entitlements list page to the customer portal (`/session/entitlements`)
- Implements the new `PortalGrantResponse` shape per API PR #1212 — flat `license_key_*` fields replaced with nested `LicenseKeyGrant` and `DigitalProductDelivery` objects
- Digital delivery data is read directly from `grant.digital_product_delivery` (embedded on the list response) — no separate `/download` fetch needed in the grant detail sheet
- License key is read from `grant.license_key.key` and `grant.license_key.expires_at`

## New files

- `src/app/session/entitlements/actions.ts` — server actions + all grant response types (`PortalGrantResponse`, `LicenseKeyGrant`, `DigitalProductDelivery`, `DownloadResponse`)
- `src/components/session/entitlements/entitlements-columns.tsx` — table column definitions + `GrantDetailSheet` (shows LK key reveal/hide, DPD files + external link + instructions, OAuth/Telegram action buttons)
- `src/components/session/entitlements/entitlements-table.tsx` — `EntitlementsTable` component wrapping `BaseDataGrid`

## Type changes from old → new shape

| Old (flat) | New (nested) |
|---|---|
| `grant.license_key` (string) | `grant.license_key.key` |
| `grant.license_key_expires_at` | `grant.license_key.expires_at` |
| `grant.license_key_activations_limit` | `grant.license_key.activations_limit` |
| `grant.license_key_activations_used` | `grant.license_key.activations_used` |
| `grant.license_key_status` | removed — use `grant.status` |
| separate `/download` fetch | `grant.digital_product_delivery` embedded |