### PR TITLE
feat(subscriptions): support stacked discount codes on plan change

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -207,7 +207,17 @@
     "previewFailed": "فشل تحميل المعاينة. يرجى المحاولة مرة أخرى.",
     "changeFailed": "فشل تغيير الخطة. يرجى المحاولة مرة أخرى.",
     "changeSuccess": "تم تغيير الخطة بنجاح",
-    "addonRequired": "يرجى تحديد إضافة واحدة على الأقل بكمية 1 أو أكثر."
+    "addonRequired": "يرجى تحديد إضافة واحدة على الأقل بكمية 1 أو أكثر.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "تعديل",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -207,7 +207,17 @@
     "previewFailed": "No s’ha pogut carregar la previsualització. Torna-ho a provar.",
     "changeFailed": "No s’ha pogut canviar el pla. Torna-ho a provar.",
     "changeSuccess": "El pla s’ha canviat correctament",
-    "addonRequired": "Selecciona com a mínim un complement amb quantitat 1 o superior."
+    "addonRequired": "Selecciona com a mínim un complement amb quantitat 1 o superior.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Edita",

--- a/messages/de.json
+++ b/messages/de.json
@@ -207,7 +207,17 @@
     "previewFailed": "Vorschau konnte nicht geladen werden. Bitte versuchen Sie es erneut.",
     "changeFailed": "Plan konnte nicht geändert werden. Bitte versuchen Sie es erneut.",
     "changeSuccess": "Plan erfolgreich geändert",
-    "addonRequired": "Bitte wählen Sie mindestens ein Add-on mit Menge 1 oder mehr aus."
+    "addonRequired": "Bitte wählen Sie mindestens ein Add-on mit Menge 1 oder mehr aus.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Bearbeiten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -207,7 +207,17 @@
     "previewFailed": "Failed to load preview. Please try again.",
     "changeFailed": "Failed to change plan. Please try again.",
     "changeSuccess": "Plan changed successfully",
-    "addonRequired": "Please select at least one add-on with quantity 1 or more."
+    "addonRequired": "Please select at least one add-on with quantity 1 or more.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again.",
+    "discountMaxReached": "Maximum of 20 discount codes allowed"
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Edit",

--- a/messages/es.json
+++ b/messages/es.json
@@ -207,7 +207,17 @@
     "previewFailed": "No se pudo cargar la vista previa. Inténtalo de nuevo.",
     "changeFailed": "No se pudo cambiar el plan. Inténtalo de nuevo.",
     "changeSuccess": "Plan cambiado correctamente",
-    "addonRequired": "Selecciona al menos un add-on con cantidad 1 o superior."
+    "addonRequired": "Selecciona al menos un add-on con cantidad 1 o superior.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Editar",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -207,7 +207,17 @@
     "previewFailed": "Échec du chargement de l’aperçu. Veuillez réessayer.",
     "changeFailed": "Échec du changement de forfait. Veuillez réessayer.",
     "changeSuccess": "Forfait changé avec succès",
-    "addonRequired": "Veuillez sélectionner au moins un add-on avec une quantité de 1 ou plus."
+    "addonRequired": "Veuillez sélectionner au moins un add-on avec une quantité de 1 ou plus.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Modifier",

--- a/messages/he.json
+++ b/messages/he.json
@@ -207,7 +207,17 @@
     "previewFailed": "טעינת התצוגה המקדימה נכשלה. נסו שוב.",
     "changeFailed": "שינוי התוכנית נכשל. נסו שוב.",
     "changeSuccess": "התוכנית שונתה בהצלחה",
-    "addonRequired": "נא לבחור לפחות תוסף אחד עם כמות 1 ומעלה."
+    "addonRequired": "נא לבחור לפחות תוסף אחד עם כמות 1 ומעלה.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "עריכה",

--- a/messages/id.json
+++ b/messages/id.json
@@ -207,7 +207,17 @@
     "previewFailed": "Gagal memuat pratinjau. Silakan coba lagi.",
     "changeFailed": "Gagal mengubah paket. Silakan coba lagi.",
     "changeSuccess": "Paket berhasil diubah",
-    "addonRequired": "Silakan pilih setidaknya satu add-on dengan kuantitas 1 atau lebih."
+    "addonRequired": "Silakan pilih setidaknya satu add-on dengan kuantitas 1 atau lebih.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Edit",

--- a/messages/it.json
+++ b/messages/it.json
@@ -207,7 +207,17 @@
     "previewFailed": "Impossibile caricare l'anteprima. Riprova.",
     "changeFailed": "Impossibile cambiare piano. Riprova.",
     "changeSuccess": "Piano cambiato correttamente",
-    "addonRequired": "Seleziona almeno un add-on con quantità pari o superiore a 1."
+    "addonRequired": "Seleziona almeno un add-on con quantità pari o superiore a 1.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Modifica",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -207,7 +207,17 @@
     "previewFailed": "プレビューの読み込みに失敗しました。もう一度お試しください。",
     "changeFailed": "プランの変更に失敗しました。もう一度お試しください。",
     "changeSuccess": "プランを変更しました",
-    "addonRequired": "数量が 1 以上のアドオンを少なくとも 1 つ選択してください。"
+    "addonRequired": "数量が 1 以上のアドオンを少なくとも 1 つ選択してください。",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "編集",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -207,7 +207,17 @@
     "previewFailed": "미리보기를 불러오지 못했습니다. 다시 시도해 주세요.",
     "changeFailed": "플랜 변경에 실패했습니다. 다시 시도해 주세요.",
     "changeSuccess": "플랜이 성공적으로 변경되었습니다",
-    "addonRequired": "수량 1개 이상인 애드온을 최소 1개 선택해 주세요."
+    "addonRequired": "수량 1개 이상인 애드온을 최소 1개 선택해 주세요.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "수정",

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -207,7 +207,17 @@
     "previewFailed": "Gagal memuatkan pratonton. Sila cuba lagi.",
     "changeFailed": "Gagal menukar pelan. Sila cuba lagi.",
     "changeSuccess": "Pelan berjaya ditukar",
-    "addonRequired": "Sila pilih sekurang-kurangnya satu add-on dengan kuantiti 1 atau lebih."
+    "addonRequired": "Sila pilih sekurang-kurangnya satu add-on dengan kuantiti 1 atau lebih.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Edit",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -207,7 +207,17 @@
     "previewFailed": "Preview laden mislukt. Probeer het opnieuw.",
     "changeFailed": "Plan wijzigen mislukt. Probeer het opnieuw.",
     "changeSuccess": "Plan succesvol gewijzigd",
-    "addonRequired": "Selecteer minimaal één add-on met hoeveelheid 1 of meer."
+    "addonRequired": "Selecteer minimaal één add-on met hoeveelheid 1 of meer.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Bewerken",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -207,7 +207,17 @@
     "previewFailed": "Nie udało się załadować podglądu. Spróbuj ponownie.",
     "changeFailed": "Nie udało się zmienić planu. Spróbuj ponownie.",
     "changeSuccess": "Pomyślnie zmieniono plan",
-    "addonRequired": "Wybierz co najmniej jeden add-on z ilością 1 lub większą."
+    "addonRequired": "Wybierz co najmniej jeden add-on z ilością 1 lub większą.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Edytuj",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -207,7 +207,17 @@
     "previewFailed": "Falha ao carregar a pré-visualização. Tente novamente.",
     "changeFailed": "Falha ao alterar o plano. Tente novamente.",
     "changeSuccess": "Plano alterado com sucesso",
-    "addonRequired": "Selecione pelo menos um add-on com quantidade 1 ou superior."
+    "addonRequired": "Selecione pelo menos um add-on com quantidade 1 ou superior.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Editar",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -207,7 +207,17 @@
     "previewFailed": "Nu s-a putut încărca previzualizarea. Vă rugăm să încercați din nou.",
     "changeFailed": "Nu s-a putut schimba planul. Vă rugăm să încercați din nou.",
     "changeSuccess": "Planul a fost schimbat cu succes",
-    "addonRequired": "Vă rugăm să selectați cel puțin un add-on cu cantitatea 1 sau mai mult."
+    "addonRequired": "Vă rugăm să selectați cel puțin un add-on cu cantitatea 1 sau mai mult.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Editați",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -207,7 +207,17 @@
     "previewFailed": "Не удалось загрузить предварительный расчёт. Пожалуйста, попробуйте ещё раз.",
     "changeFailed": "Не удалось сменить план. Пожалуйста, попробуйте ещё раз.",
     "changeSuccess": "План успешно изменён",
-    "addonRequired": "Пожалуйста, выберите хотя бы одно дополнение с количеством 1 или больше."
+    "addonRequired": "Пожалуйста, выберите хотя бы одно дополнение с количеством 1 или больше.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Редактировать",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -207,7 +207,17 @@
     "previewFailed": "Det gick inte att ladda förhandsvisningen. Försök igen.",
     "changeFailed": "Det gick inte att byta plan. Försök igen.",
     "changeSuccess": "Planen ändrades",
-    "addonRequired": "Välj minst ett tillägg med antal 1 eller fler."
+    "addonRequired": "Välj minst ett tillägg med antal 1 eller fler.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Redigera",

--- a/messages/th.json
+++ b/messages/th.json
@@ -207,7 +207,17 @@
     "previewFailed": "โหลดตัวอย่างไม่สำเร็จ โปรดลองอีกครั้ง",
     "changeFailed": "เปลี่ยนแผนไม่สำเร็จ โปรดลองอีกครั้ง",
     "changeSuccess": "เปลี่ยนแผนเรียบร้อยแล้ว",
-    "addonRequired": "โปรดเลือกอย่างน้อยหนึ่ง add-on ที่มีจำนวน 1 ขึ้นไป"
+    "addonRequired": "โปรดเลือกอย่างน้อยหนึ่ง add-on ที่มีจำนวน 1 ขึ้นไป",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "แก้ไข",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -207,7 +207,17 @@
     "previewFailed": "Önizleme yüklenemedi. Lütfen tekrar deneyin.",
     "changeFailed": "Plan değiştirilemedi. Lütfen tekrar deneyin.",
     "changeSuccess": "Plan başarıyla değiştirildi",
-    "addonRequired": "Lütfen miktarı 1 veya daha fazla olan en az bir add-on seçin."
+    "addonRequired": "Lütfen miktarı 1 veya daha fazla olan en az bir add-on seçin.",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "Düzenle",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -207,7 +207,17 @@
     "previewFailed": "加载预览失败。请重试。",
     "changeFailed": "更换方案失败。请重试。",
     "changeSuccess": "方案更换成功",
-    "addonRequired": "请至少选择一个数量为 1 或以上的附加项。"
+    "addonRequired": "请至少选择一个数量为 1 或以上的附加项。",
+    "discountsTitle": "Discounts",
+    "discountsDescription": "Add or remove discount codes for the new plan. Max 20.",
+    "discountsSave": "Save",
+    "discountsPlaceholder": "Enter discount code",
+    "discountsAdd": "Add discount",
+    "discountsAddMore": "Add more",
+    "discountsRemove": "Remove discount code",
+    "discountsApplied": "Discounts applied",
+    "discountMaxReached": "Maximum of 20 discount codes allowed",
+    "discountsFailed": "Failed to apply discount codes. Please check the codes and try again."
   },
   "UpdatePaymentMethodSheet": {
     "editButton": "编辑",

--- a/src/app/session/subscriptions/[id]/page.tsx
+++ b/src/app/session/subscriptions/[id]/page.tsx
@@ -123,6 +123,7 @@ function HeaderActions({
           subscriptionId={subscriptionId}
           currentAddons={subscription.addons ?? []}
           currentQuantity={subscription.quantity ?? 1}
+          currentDiscounts={subscription.discounts}
           productCollection={productCollection ?? null}
           allowMultipleSubscriptions={allowMultipleSubscriptions}
         />

--- a/src/app/session/subscriptions/[id]/types.ts
+++ b/src/app/session/subscriptions/[id]/types.ts
@@ -43,6 +43,25 @@ export interface Product {
   name: string;
 }
 
+export interface DiscountDetailResponse {
+  position: number;
+  discount_id: string;
+  business_id: string;
+  type: string;
+  code: string;
+  amount: number;
+  times_used: number;
+  restricted_to?: string[] | null;
+  created_at: string;
+  preserve_on_plan_change: boolean;
+  metadata?: Record<string, unknown> | null;
+  cycles_remaining?: number | null;
+  expires_at?: string | null;
+  name?: string | null;
+  subscription_cycles?: number | null;
+  usage_limit?: number | null;
+}
+
 export interface SubscriptionDetailsData {
   billing: Billing;
   addons: AddOn[];
@@ -53,6 +72,7 @@ export interface SubscriptionDetailsData {
   customer: Customer;
   discount_cycles_remaining: number;
   discount_id: string;
+  discounts?: DiscountDetailResponse[] | null;
   expires_at: string;
   payment_method_id?: string;
   metadata: Record<string, string>;
@@ -114,6 +134,7 @@ export interface ChangeSubscriptionPlanParams {
   subscription_id: string;
   data: {
     addons: AddOn[] | null;
+    discount_codes?: string[] | null;
     metadata: Record<string, string> | null;
     product_id: string;
     proration_billing_mode: ProrationBillingMode;
@@ -182,6 +203,7 @@ export interface ChangeSubscriptionPlanPreviewParams {
   subscription_id: string;
   data: {
     addons: AddOn[] | null;
+    discount_codes?: string[] | null;
     metadata: Record<string, string> | null;
     product_id: string;
     proration_billing_mode: ProrationBillingMode;
@@ -243,6 +265,7 @@ export interface NewPlan {
   };
   discount_cycles_remaining: number;
   discount_id: string;
+  discounts?: DiscountDetailResponse[] | null;
   expires_at: string;
   metadata: Record<string, string>;
   meters: Meter[];

--- a/src/components/session/subscriptions/change-plan-sheet.tsx
+++ b/src/components/session/subscriptions/change-plan-sheet.tsx
@@ -24,6 +24,7 @@ import { PlanPreview } from "./plan-preview";
 import type {
   ProductCollectionData,
   ProductCollectionProduct,
+  DiscountDetailResponse,
 } from "@/app/session/subscriptions/[id]/types";
 import type { AddOn } from "@/app/session/subscriptions/[id]/types";
 import { useTranslations } from "next-intl";
@@ -81,6 +82,7 @@ interface ChangePlanSheetProps {
   subscriptionId: string;
   currentAddons: AddOn[];
   currentQuantity: number;
+  currentDiscounts?: DiscountDetailResponse[] | null;
   productCollection?: ProductCollectionData | null;
   allowMultipleSubscriptions?: boolean;
 }
@@ -128,6 +130,7 @@ export function ChangePlanSheet({
   subscriptionId,
   currentAddons,
   currentQuantity,
+  currentDiscounts,
   productCollection,
   allowMultipleSubscriptions = true,
 }: ChangePlanSheetProps) {
@@ -384,6 +387,7 @@ export function ChangePlanSheet({
             currentQuantity={currentQuantity}
             subscriptionId={subscriptionId}
             currentAddons={currentAddons}
+            currentDiscounts={currentDiscounts}
             onBackClick={() => setCurrentView("select")}
             onConfirm={() => {
               setOpen(false);

--- a/src/components/session/subscriptions/plan-preview.tsx
+++ b/src/components/session/subscriptions/plan-preview.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef, useMemo } from "react";
-import { ArrowLeft, Info, Minus, Plus } from "lucide-react";
+import { ArrowLeft, Info, Minus, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { SheetHeader } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -18,6 +19,7 @@ import type {
   ProrationBillingMode,
   ProductCollectionProduct,
   ChangeSubscriptionPlanPreviewResponse,
+  DiscountDetailResponse,
   LineItem,
   CustomerPortalAddonDetail,
 } from "@/app/session/subscriptions/[id]/types";
@@ -53,6 +55,7 @@ interface PlanPreviewProps {
   quantity: number;
   currentQuantity: number;
   currentAddons: AddOn[];
+  currentDiscounts?: DiscountDetailResponse[] | null;
 }
 
 const asCurrencyCode = (
@@ -512,6 +515,7 @@ export function PlanPreview({
   quantity,
   currentQuantity,
   currentAddons,
+  currentDiscounts,
 }: PlanPreviewProps) {
   const t = useTranslations("PlanPreview");
   const [isConfirming, setIsConfirming] = useState(false);
@@ -523,7 +527,48 @@ export function PlanPreview({
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [editableAddons, setEditableAddons] = useState<AddOn[]>([]);
   const [productAddons, setProductAddons] = useState<CustomerPortalAddonDetail[]>([]);
+  const initialDiscountCodes = useMemo(
+    () =>
+      (currentDiscounts || [])
+        .slice()
+        .sort((a, b) => a.position - b.position)
+        .map((d) => d.code),
+    [currentDiscounts],
+  );
+  const [discountCodes, setDiscountCodes] = useState<string[]>(initialDiscountCodes);
+  const [savedCodes, setSavedCodes] = useState<string[]>(initialDiscountCodes);
+  const [discountError, setDiscountError] = useState(false);
+  const [isSavingDiscounts, setIsSavingDiscounts] = useState(false);
   const router = useRouter();
+
+  const discountsChanged =
+    discountCodes
+      .map((c) => c.trim())
+      .filter(Boolean)
+      .join(",") !== savedCodes.join(",");
+
+  const handleAddDiscount = () => {
+    if (discountCodes.length >= 20) {
+      toast.error(t("discountMaxReached"));
+      return;
+    }
+    setDiscountCodes((prev) => [...prev, ""]);
+    setDiscountError(false);
+  };
+
+  const handleRemoveDiscount = (index: number) => {
+    setDiscountCodes((prev) => prev.filter((_, i) => i !== index));
+    setDiscountError(false);
+  };
+
+  const handleEditDiscount = (index: number, value: string) => {
+    setDiscountCodes((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+    setDiscountError(false);
+  };
 
   const isUsageBasedProduct = (selectedProduct?.meters_count ?? 0) > 0;
   const requiresAtLeastOneAddon = currentAddons.length > 0 && !isUsageBasedProduct;
@@ -631,7 +676,9 @@ export function PlanPreview({
         const addonsToSend = isUsageBasedProduct 
           ? null 
           : editableAddons.filter(a => a.quantity > 0);
-        
+        const savedCodesDiffer =
+          savedCodes.join(",") !== initialDiscountCodes.join(",");
+
         const result = await changeSubscriptionPlanPreview({
           subscription_id: subscriptionId,
           data: {
@@ -640,6 +687,7 @@ export function PlanPreview({
             proration_billing_mode: billingMode,
             addons: addonsToSend && addonsToSend.length > 0 ? addonsToSend : null,
             metadata: null,
+            ...(savedCodesDiffer ? { discount_codes: savedCodes } : {}),
           },
         });
         if (!result.success) {
@@ -667,7 +715,50 @@ export function PlanPreview({
     editableAddons,
     onBackClick,
     isUsageBasedProduct,
+    savedCodes,
+    initialDiscountCodes,
+    t,
   ]);
+
+  const handleSaveDiscounts = async () => {
+    if (!selectedProduct) return;
+    const trimmed = discountCodes.map((c) => c.trim()).filter(Boolean);
+    const addonsToSend = isUsageBasedProduct
+      ? null
+      : editableAddons.filter((a) => a.quantity > 0);
+
+    setIsSavingDiscounts(true);
+    setDiscountError(false);
+    try {
+      const result = await changeSubscriptionPlanPreview({
+        subscription_id: subscriptionId,
+        data: {
+          product_id: selectedProduct.product_id,
+          quantity: Math.max(quantity, 1),
+          proration_billing_mode: billingMode,
+          addons:
+            addonsToSend && addonsToSend.length > 0 ? addonsToSend : null,
+          metadata: null,
+          discount_codes: trimmed,
+        },
+      });
+      if (!result.success) {
+        setDiscountError(true);
+        toast.error(result.error || t("discountsFailed"));
+        return;
+      }
+      setPreviewData(result.data);
+      setDiscountCodes(trimmed);
+      setSavedCodes(trimmed);
+      toast.success(t("discountsApplied"));
+    } catch (error) {
+      console.error("Failed to apply discounts:", error);
+      setDiscountError(true);
+      parseError(error, t("discountsFailed"));
+    } finally {
+      setIsSavingDiscounts(false);
+    }
+  };
 
   
   if (!selectedProduct) {
@@ -722,6 +813,8 @@ export function PlanPreview({
         ? []
         : editableAddons.filter(a => a.quantity > 0);
 
+      const savedCodesDiffer =
+        savedCodes.join(",") !== initialDiscountCodes.join(",");
       const result = await changeSubscriptionPlan({
         subscription_id: subscriptionId,
         data: {
@@ -730,6 +823,7 @@ export function PlanPreview({
           proration_billing_mode: billingMode,
           addons: addonsToSend,
           metadata: null,
+          ...(savedCodesDiffer ? { discount_codes: savedCodes } : {}),
         },
       });
       if (!result.success) {
@@ -883,6 +977,77 @@ export function PlanPreview({
               />
             )}
 
+            <Card className="border-border-secondary">
+              <CardContent className="p-4 flex flex-col gap-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex flex-col">
+                    <h5 className="text-text-primary font-medium text-sm">
+                      {t("discountsTitle")}
+                    </h5>
+                    <p className="text-text-secondary text-xs">
+                      {t("discountsDescription")}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    onClick={handleSaveDiscounts}
+                    disabled={isSavingDiscounts || !discountsChanged}
+                  >
+                    {isSavingDiscounts ? (
+                      <Loading className="h-4 w-4" />
+                    ) : (
+                      t("discountsSave")
+                    )}
+                  </Button>
+                </div>
+
+                {discountCodes.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    {discountCodes.map((code, index) => (
+                      <div key={index} className="flex items-center gap-2">
+                        <Input
+                          value={code}
+                          onChange={(e) =>
+                            handleEditDiscount(index, e.target.value)
+                          }
+                          placeholder={t("discountsPlaceholder")}
+                          className={`flex-1 h-9 ${
+                            discountError
+                              ? "border-border-error-primary focus-visible:ring-border-error-primary"
+                              : ""
+                          }`}
+                          disabled={isSavingDiscounts}
+                        />
+                        <Button
+                          variant="secondary"
+                          size="icon"
+                          className="h-9 w-9 text-text-secondary hover:text-text-error-primary"
+                          onClick={() => handleRemoveDiscount(index)}
+                          disabled={isSavingDiscounts}
+                          aria-label={t("discountsRemove")}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleAddDiscount}
+                  disabled={discountCodes.length >= 20 || isSavingDiscounts}
+                  className="w-fit"
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  {discountCodes.length === 0
+                    ? t("discountsAdd")
+                    : t("discountsAddMore")}
+                </Button>
+              </CardContent>
+            </Card>
+
             <div className="flex flex-col gap-3">
               <Card className="border-border-secondary">
                 <CardContent className="p-4 flex flex-col gap-0 bg-button-secondary-bg rounded-lg">
@@ -953,7 +1118,14 @@ export function PlanPreview({
             <Button
               className="w-full"
               onClick={handleConfirmChangePlan}
-              disabled={isConfirming || isLoadingPreview || !previewData}
+              disabled={
+                isConfirming ||
+                isLoadingPreview ||
+                !previewData ||
+                isSavingDiscounts ||
+                discountsChanged ||
+                discountError
+              }
               loading={isConfirming}
             >
               {previewData && summary


### PR DESCRIPTION
## Summary

Adds stacked discount support to the customer portal's change-plan flow so customers can apply, edit, and remove discount codes on their subscription. Mirrors the merchant dashboard PR.

## What's new

- **Editable list of discount codes** in the plan-preview sheet. Each row is an input + delete button, with an **Add discount** / **Add more** button to append a new empty row.
- **Save button** runs `POST /customer-portal/subscriptions/{id}/change-plan/preview` with the current codes, updates the preview totals, and shows a success toast.
- **Inline error state** — failed codes turn the input borders red and surface a backend-provided error toast.
- **Confirm Plan Change** is disabled while there are unsaved discount edits or an active error.
- **Pre-existing discounts** on the subscription are seeded into the editable list so customers can adjust them in the same flow.

## API alignment

Per `UpdateSubscriptionPlanReq` in the customer portal OpenAPI spec:

- `discount_codes` (array, max 20) is sent only when the saved set differs from the initial set. Omitted otherwise so the server keeps discounts marked `preserve_on_plan_change=true` per spec semantics.
- The deprecated single `discount_code` field is not used.
- Empty array clears all discounts.

## Type changes (`types.ts`)

- New `DiscountDetailResponse` interface.
- `SubscriptionDetailsData.discounts?` and `NewPlan.discounts?` added.
- `ChangeSubscriptionPlanParams.data.discount_codes?` and `ChangeSubscriptionPlanPreviewParams.data.discount_codes?` added.

## i18n

Added 10 new keys under the `PlanPreview` namespace (`discountsTitle`, `discountsDescription`, `discountsSave`, `discountsPlaceholder`, `discountsAdd`, `discountsAddMore`, `discountsRemove`, `discountsApplied`, `discountsFailed`, `discountMaxReached`) across all 21 locales. English copy is used as the fallback for the non-English locales so `next-intl` doesn't throw `MISSING_MESSAGE`; translators can localize these in a follow-up.

## Files changed

- `src/app/session/subscriptions/[id]/types.ts`
- `src/app/session/subscriptions/[id]/page.tsx`
- `src/components/session/subscriptions/change-plan-sheet.tsx`
- `src/components/session/subscriptions/plan-preview.tsx`
- `messages/*.json` (21 locales)