### PR TITLE
fix(subscriptions): use Button loading prop for discount save

### DIFF
--- a/src/app/session/entitlements/actions.ts
+++ b/src/app/session/entitlements/actions.ts
@@ -98,7 +98,6 @@ export async function fetchPortalEntitlements(): Promise<PortalGrantResponse[]> 
     }
 
     const data = await response.json();
-    console.log(JSON.stringify(data, null, 2));
     return data.items || [];
   } catch (error) {
     parseError(error, "Failed to fetch entitlements");

--- a/src/components/session/subscriptions/plan-preview.tsx
+++ b/src/components/session/subscriptions/plan-preview.tsx
@@ -992,12 +992,9 @@ export function PlanPreview({
                     size="sm"
                     onClick={handleSaveDiscounts}
                     disabled={isSavingDiscounts || !discountsChanged}
+                    loading={isSavingDiscounts}
                   >
-                    {isSavingDiscounts ? (
-                      <Loading className="h-4 w-4" />
-                    ) : (
-                      t("discountsSave")
-                    )}
+                    {t("discountsSave")}
                   </Button>
                 </div>
 


### PR DESCRIPTION
## Summary

Follow-up to the merged stacked-discounts PR. The customer portal's `Loading` component doesn't accept a `className` prop, which broke the TypeScript build on the discount Save button. Switching to the `Button`'s built-in `loading` prop keeps the same UX without modifying the shared `Loading` component.

```diff
- <Button size="sm" onClick={handleSaveDiscounts} disabled={isSavingDiscounts || !discountsChanged}>
-   {isSavingDiscounts ? <Loading className="h-4 w-4" /> : t("discountsSave")}
- </Button>
+ <Button size="sm" onClick={handleSaveDiscounts} disabled={isSavingDiscounts || !discountsChanged} loading={isSavingDiscounts}>
+   {t("discountsSave")}
+ </Button>
```

This matches how every other button in the app shows its inline loader (`Button.loading` overlays a centered `<Loading />` — see `src/components/ui/button.tsx:148–160`).

Also drops a stray `console.log(JSON.stringify(data, null, 2))` in `fetchPortalEntitlements` that was committed unrelated to subscriptions.

## Verified

- `npx next build` passes locally