### PR TITLE
feat(login): show test mode banner and disable submit on login page

### DIFF
--- a/src/app/login/[business_id]/page.tsx
+++ b/src/app/login/[business_id]/page.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import LoginCard from "../../../components/login/login-card";
+import InfoBox from "@/components/custom/InfoBox";
 import parseError from "@/lib/serverErrorHelper";
+import { getServerMode } from "@/lib/server-http";
 import { ssrProxyFetch } from "@/lib/ssr-proxy";
 import { cache } from "react";
 import type { LoginBusiness } from "@/components/login/login-form";
@@ -54,13 +56,24 @@ const Page = async ({
 }) => {
   const { business_id } = await params;
   const business = await getBusinessForLogin(business_id);
+  const mode = await getServerMode();
+  const isTestMode = mode === "test";
 
   return (
     <main className="w-full bg-bg-primary h-full min-h-[100dvh] flex mx-auto max-w-[2160px]">
-      <section className="lg:w-1/2 min-h-[100dvh] relative overflow-auto w-full h-full flex px-5 md:px-10 justify-center items-center">
+      <section className="lg:w-1/2 min-h-[100dvh] relative overflow-auto w-full h-full flex flex-col px-5 md:px-10 justify-center items-center">
+        {isTestMode && (
+          <div className="w-full max-w-md pt-5">
+            <InfoBox
+              color="yellow"
+              message="You’re currently in test mode. Emails will not be sent. To test email delivery, switch to live mode."
+            />
+          </div>
+        )}
         <LoginCard
           className="flex h-[100dvh] justify-center flex-col gap-8 w-full items-center border-none"
           initialBusiness={business}
+          isTestMode={isTestMode}
         />
       </section>
       <section className="w-1/2 hidden lg:flex h-[100dvh] p-6 rounded-xl overflow-hidden">

--- a/src/components/custom/InfoBox.tsx
+++ b/src/components/custom/InfoBox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 
 import { IconProps, Info } from "@phosphor-icons/react";

--- a/src/components/login/login-card.tsx
+++ b/src/components/login/login-card.tsx
@@ -7,15 +7,18 @@ import FooterPill from "../footer-pill";
 const LoginCard = ({
   className,
   initialBusiness,
+  isTestMode = false,
 }: {
   className?: string;
   initialBusiness: LoginBusiness | null;
+  isTestMode?: boolean;
 }) => {
   return (
     <Card className={cn("w-full relative h-full overflow-hidden", className)}>
       <LoginForm
         className="w-full max-w-md mx-auto"
         initialBusiness={initialBusiness}
+        isTestMode={isTestMode}
       />
       <div className="w-full flex justify-center absolute bottom-4 md:bottom-8">
         <FooterPill align="center" isFixed={false} />

--- a/src/components/login/login-form.tsx
+++ b/src/components/login/login-form.tsx
@@ -69,9 +69,11 @@ const MagicLinkStatus = ({
 export const LoginForm = ({
   className,
   initialBusiness,
+  isTestMode = false,
 }: {
   className?: string;
   initialBusiness: LoginBusiness | null;
+  isTestMode?: boolean;
 }) => {
   const t = useTranslations("LoginForm");
   const emailSchema = useMemo(
@@ -208,7 +210,7 @@ export const LoginForm = ({
 
               <Button
                 type="submit"
-                disabled={isLoading || !!turnstileState.error}
+                disabled={isLoading || !!turnstileState.error || isTestMode}
               >
                 {isLoading ? t("sending") : t("getAccessLink")}
               </Button>


### PR DESCRIPTION
## Summary
- Show an `InfoBox` on `/login/[business_id]` when the request resolves to test mode, informing users that emails will not be sent and to switch to live mode to test email delivery.
- Disable the "Get access link" submit button in test mode to prevent attempts that won't deliver.

## Changes
- `src/app/login/[business_id]/page.tsx`: resolve mode server-side via `getServerMode()` and render `<InfoBox color="yellow" />` above `<LoginCard />` when in test mode. Pass `isTestMode` down to `LoginCard`.
- `src/components/login/login-card.tsx`: accept and forward `isTestMode` prop to `LoginForm`.
- `src/components/login/login-form.tsx`: accept `isTestMode` prop and include it in the submit button's `disabled` condition.

## Notes
- Test mode is determined by the existing `getServerMode()` helper (host-based: `localhost:3000` or non-`customer` subdomain).
- Uses the existing `InfoBox` component from `@/components/custom/InfoBox` with `color="yellow"` for a cautionary tone.
- No change in live mode behavior — banner is hidden and the button works as before.

---
*Created with [Squirrels](https://squirrels.dodopayments.tech/session/9b82170e3867db61eb64711b1b720e56)*