### PR TITLE
feat(entitlements): add Notion OAuth delivery notes for async template delivery

### DIFF
--- a/src/components/session/entitlements/entitlements-columns.tsx
+++ b/src/components/session/entitlements/entitlements-columns.tsx
@@ -298,13 +298,8 @@ function ActionCell({ raw }: { raw: PortalGrantResponse }) {
                                 setNotionOpen(false);
                                 await handleOAuthConnect();
                             }}
-                            disabled={connecting}
                         >
-                            {connecting ? (
-                                <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                            ) : (
-                                <ExternalLink className="w-4 h-4 mr-2" />
-                            )}
+                            <ExternalLink className="w-4 h-4 mr-2" />
                             Continue to Notion
                         </Button>
                     </div>
@@ -482,7 +477,7 @@ function GrantDetailSheet({
                         </p>
                     )}
 
-                    {isNotion && grant.status !== "Delivered" && (
+                    {isNotion && grant.status === "Pending" && (
                         <div className="rounded-lg border border-border-secondary bg-card p-3 flex gap-2.5">
                             <Info className="w-4 h-4 shrink-0 mt-0.5 text-text-secondary" />
                             <div className="space-y-2 text-sm text-text-secondary">

--- a/src/components/session/entitlements/entitlements-columns.tsx
+++ b/src/components/session/entitlements/entitlements-columns.tsx
@@ -24,7 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
-import { Eye, EyeOff, Download, Loader2, ExternalLink, KeyRound, FileMinus } from "lucide-react";
+import { Eye, EyeOff, Download, Loader2, ExternalLink, KeyRound, FileMinus, Info } from "lucide-react";
 import { Mode } from "@/lib/http";
 
 export interface EntitlementRow {
@@ -70,6 +70,9 @@ function ActionCell({ raw }: { raw: PortalGrantResponse }) {
     const [telegramOpen, setTelegramOpen] = useState(false);
     const [telegramUserId, setTelegramUserId] = useState("");
     const [telegramSubmitting, setTelegramSubmitting] = useState(false);
+    const [notionOpen, setNotionOpen] = useState(false);
+
+    const isNotion = raw.entitlement.integration_type === "notion";
 
     const handleOAuthConnect = async () => {
         setConnecting(true);
@@ -135,7 +138,7 @@ function ActionCell({ raw }: { raw: PortalGrantResponse }) {
                     <Button
                         variant="outline"
                         size="sm"
-                        onClick={handleOAuthConnect}
+                        onClick={isNotion ? () => setNotionOpen(true) : handleOAuthConnect}
                         disabled={connecting}
                     >
                         {connecting ? (
@@ -261,6 +264,52 @@ function ActionCell({ raw }: { raw: PortalGrantResponse }) {
                     </div>
                 </SheetContent>
             </Sheet>
+            <Sheet open={notionOpen} onOpenChange={setNotionOpen}>
+                <SheetContent
+                    className="sm:max-w-md mx-auto border-border-secondary rounded-xl border m-6"
+                    floating
+                    side="right"
+                >
+                    <SheetHeader>
+                        <SheetTitle>Connect Notion</SheetTitle>
+                        <SheetDescription>
+                            Before you continue, please review the following.
+                        </SheetDescription>
+                    </SheetHeader>
+                    <Separator className="my-4" />
+                    <div className="flex flex-col gap-4">
+                        <div className="rounded-lg border border-border-secondary bg-card p-3 flex gap-2.5">
+                            <Info className="w-4 h-4 shrink-0 mt-0.5 text-text-secondary" />
+                            <div className="space-y-2 text-sm text-text-secondary">
+                                <p>
+                                    On the Notion authorization page, the page you select will be used as the destination — your template will be added as a{" "}
+                                    <span className="text-text-primary font-medium">sub-page</span> under it.
+                                </p>
+                                <p>
+                                    Delivery is asynchronous and may take up to{" "}
+                                    <span className="text-text-primary font-medium">5 minutes</span> to appear in your Notion workspace after you authorize access.
+                                </p>
+                            </div>
+                        </div>
+
+                        <Button
+                            className="w-full mt-2"
+                            onClick={async () => {
+                                setNotionOpen(false);
+                                await handleOAuthConnect();
+                            }}
+                            disabled={connecting}
+                        >
+                            {connecting ? (
+                                <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                            ) : (
+                                <ExternalLink className="w-4 h-4 mr-2" />
+                            )}
+                            Continue to Notion
+                        </Button>
+                    </div>
+                </SheetContent>
+            </Sheet>
         </>
     );
 }
@@ -296,6 +345,7 @@ function GrantDetailSheet({
     const isLicenseKey = grant?.entitlement.integration_type === "license_key";
     const isDigitalFiles = grant?.entitlement.integration_type === "digital_files";
     const isFramer = grant?.entitlement.integration_type === "framer";
+    const isNotion = grant?.entitlement.integration_type === "notion";
 
     const handleReconnect = async () => {
         if (!grant) return;
@@ -430,6 +480,22 @@ function GrantDetailSheet({
                         <p className="text-sm text-text-secondary">
                             Your Framer template link will be available once the entitlement is delivered.
                         </p>
+                    )}
+
+                    {isNotion && grant.status !== "Delivered" && (
+                        <div className="rounded-lg border border-border-secondary bg-card p-3 flex gap-2.5">
+                            <Info className="w-4 h-4 shrink-0 mt-0.5 text-text-secondary" />
+                            <div className="space-y-2 text-sm text-text-secondary">
+                                <p>
+                                    Notion template delivery is asynchronous and may take up to{" "}
+                                    <span className="text-text-primary font-medium">5 minutes</span> to be delivered after you authorize access.
+                                </p>
+                                <p>
+                                    The template will appear as a{" "}
+                                    <span className="text-text-primary font-medium">sub-page</span> inside the page you selected on Notion&apos;s authorization screen.
+                                </p>
+                            </div>
+                        </div>
                     )}
 
                     {isFramer && grant.status === "Delivered" && (


### PR DESCRIPTION
## Summary

Notion template delivery is now asynchronous and may take up to 5 minutes to be delivered to the customer. This PR surfaces that expectation in the customer portal, along with a heads-up about how Notion's authorization screen behaves.

## Changes

In `src/components/session/entitlements/entitlements-columns.tsx`:

- **New pre-OAuth Notion confirmation sheet** — clicking "Connect" on a Notion entitlement now opens a side sheet first (instead of immediately redirecting). The sheet contains an `Info`-styled callout explaining:
  - The page the customer selects on Notion's OAuth screen will be the **parent**; the template is added as a **sub-page** under it.
  - Delivery is **asynchronous and may take up to 5 minutes** to appear after authorizing.
  - A "Continue to Notion" button triggers the existing `handleOAuthConnect` flow.
- **Notion pending note inside `GrantDetailSheet`** — the same callout is shown in the View sheet for any non-`Delivered` Notion grant, so customers who already authorized but are still waiting understand the delay. This mirrors the existing Framer / License / Digital Files patterns.
- The Connect button only branches into the new sheet for Notion grants; Discord / GitHub / Figma OAuth flows are unchanged.

## Verification

- `bunx tsc --noEmit` passes cleanly.
- `bunx eslint` on the modified file shows only one pre-existing error (`useEffect` `setVisible(false)` on the original `GrantDetailSheet`) that is present on `main` and unrelated to these changes.

---
*Created with [Squirrels](https://squirrels.dodopayments.tech/session/53c98824bca1daf2f706dccb948037c7)*