### PR TITLE
feat(subscriptions): change-plan proration settings + discount/business-name updates

### DIFF
--- a/src/app/session/subscriptions/[id]/action.ts
+++ b/src/app/session/subscriptions/[id]/action.ts
@@ -175,7 +175,6 @@ export async function changeSubscriptionPlan(
       const errorText = await response.text().catch(() => "");
       let errorMessage = "";
 
-      // Try to parse JSON error response
       try {
         const errorJson = JSON.parse(errorText);
         errorMessage = errorJson.message || errorText;
@@ -184,7 +183,7 @@ export async function changeSubscriptionPlan(
       }
 
       if (response.status === 403) {
-        errorMessage = errorMessage || "Products not in the same collection";
+        errorMessage = errorMessage || "Plan change is not allowed for this subscription";
       } else if (response.status === 404) {
         errorMessage = errorMessage || "Subscription not found";
       } else if (response.status === 422) {
@@ -229,7 +228,6 @@ export async function changeSubscriptionPlanPreview(
       const errorText = await response.text().catch(() => "");
       let errorMessage = "";
 
-      // Try to parse JSON error response
       try {
         const errorJson = JSON.parse(errorText);
         errorMessage = errorJson.message || errorText;
@@ -238,7 +236,7 @@ export async function changeSubscriptionPlanPreview(
       }
 
       if (response.status === 403) {
-        errorMessage = errorMessage || "Products not in the same collection";
+        errorMessage = errorMessage || "Plan change is not allowed for this subscription";
       } else if (response.status === 404) {
         errorMessage = errorMessage || "Subscription not found";
       } else if (response.status === 422) {

--- a/src/app/session/subscriptions/[id]/types.ts
+++ b/src/app/session/subscriptions/[id]/types.ts
@@ -13,11 +13,6 @@ export interface AddOn {
   image?: string | null;
 }
 
-export type ProrationBillingMode =
-  | "prorated_immediately"
-  | "full_immediately"
-  | "difference_immediately";
-
 export interface Billing {
   city: string;
   country: string;
@@ -139,7 +134,6 @@ export interface ChangeSubscriptionPlanParams {
     discount_codes?: string[] | null;
     metadata: Record<string, string> | null;
     product_id: string;
-    proration_billing_mode: ProrationBillingMode;
     quantity: number;
   };
 }
@@ -208,7 +202,6 @@ export interface ChangeSubscriptionPlanPreviewParams {
     discount_codes?: string[] | null;
     metadata: Record<string, string> | null;
     product_id: string;
-    proration_billing_mode: ProrationBillingMode;
     quantity: number;
   };
 }

--- a/src/components/session/subscriptions/plan-preview.tsx
+++ b/src/components/session/subscriptions/plan-preview.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/lib/currency-helper";
 import type {
   AddOn,
-  ProrationBillingMode,
   ProductCollectionProduct,
   ChangeSubscriptionPlanPreviewResponse,
   DiscountDetailResponse,
@@ -519,7 +518,6 @@ export function PlanPreview({
 }: PlanPreviewProps) {
   const t = useTranslations("PlanPreview");
   const [isConfirming, setIsConfirming] = useState(false);
-  const [billingMode] = useState<ProrationBillingMode>("prorated_immediately");
   const [isCurrentAddonsOpen, setIsCurrentAddonsOpen] = useState(false);
   const [isNewAddonsOpen, setIsNewAddonsOpen] = useState(false);
   const [previewData, setPreviewData] =
@@ -684,7 +682,6 @@ export function PlanPreview({
           data: {
             product_id: selectedProduct.product_id,
             quantity: Math.max(quantity, 1),
-            proration_billing_mode: billingMode,
             addons: addonsToSend && addonsToSend.length > 0 ? addonsToSend : null,
             metadata: null,
             ...(savedCodesDiffer ? { discount_codes: savedCodes } : {}),
@@ -711,7 +708,6 @@ export function PlanPreview({
     subscriptionId,
     selectedProduct,
     quantity,
-    billingMode,
     editableAddons,
     onBackClick,
     isUsageBasedProduct,
@@ -735,7 +731,6 @@ export function PlanPreview({
         data: {
           product_id: selectedProduct.product_id,
           quantity: Math.max(quantity, 1),
-          proration_billing_mode: billingMode,
           addons:
             addonsToSend && addonsToSend.length > 0 ? addonsToSend : null,
           metadata: null,
@@ -820,7 +815,6 @@ export function PlanPreview({
         data: {
           product_id: selectedProduct.product_id,
           quantity: Math.max(quantity, 1),
-          proration_billing_mode: billingMode,
           addons: addonsToSend,
           metadata: null,
           ...(savedCodesDiffer ? { discount_codes: savedCodes } : {}),


### PR DESCRIPTION
## Summary

Aligns the customer portal change-plan flow with the new server-side proration settings (API PR #1043), plus related subscription and login improvements that accumulated on this branch.

### Change-plan / proration (PR #1043)
- Stop sending `proration_billing_mode` on `change-plan` and `change-plan/preview`; these settings (proration mode, `effective_at`, `on_payment_failure`) are now resolved server-side from collection → business → default.
- Remove the `ProrationBillingMode` type and the now-unused `billingMode` state.
- Update the `403` message to the generic "Plan change is not allowed for this subscription" to cover the new failure cases (resolved `do_not_bill`, or `next_billing_date` when scheduling is disabled).
- Support stacked discount codes on plan change, with save + preview flows.

### Other changes on this branch
- Collect `customer_business_name` in billing details and clean up the billing error toast.
- Login page: show a test-mode banner and disable submit appropriately.
- Enable client-side rendering for the `InfoBox` component.
- Use the `Button` `loading` prop for the discount save action.

## Test plan
- [ ] Change plan (upgrade & downgrade) succeeds without sending the removed fields; verify request body is `{ product_id, quantity, addons?, metadata?, discount_codes? }`.
- [ ] 403 cases (resolved `do_not_bill`, scheduling disallowed) surface a clear message.
- [ ] Discount codes apply/preview/clear correctly on plan change.
- [ ] Billing edit saves/clears `customer_business_name`.
- [ ] Login test-mode banner shows; submit disabled state correct.

> [!NOTE]
> Review flagged a preview/confirm divergence worth a follow-up: confirm sends `addons: []` while preview/save send `null` for the empty-addons case (`plan-preview.tsx:808`), and the request body is hand-assembled in 3 places. Not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)