### PR TITLE
fix(subscriptions): send null addons on change-plan confirm for usage-based

### DIFF
--- a/src/components/session/subscriptions/plan-preview.tsx
+++ b/src/components/session/subscriptions/plan-preview.tsx
@@ -805,7 +805,7 @@ export function PlanPreview({
     try {
       setIsConfirming(true);
       const addonsToSend = isUsageBasedProduct
-        ? []
+        ? null
         : editableAddons.filter(a => a.quantity > 0);
 
       const savedCodesDiffer =
@@ -815,7 +815,7 @@ export function PlanPreview({
         data: {
           product_id: selectedProduct.product_id,
           quantity: Math.max(quantity, 1),
-          addons: addonsToSend,
+          addons: addonsToSend && addonsToSend.length > 0 ? addonsToSend : null,
           metadata: null,
           ...(savedCodesDiffer ? { discount_codes: savedCodes } : {}),
         },


### PR DESCRIPTION
## What

Align the **confirm** change-plan payload with the **preview** payload for addons.

When the updated product is usage-based, the confirm path was sending an empty array `[]` for `addons`, while both the preview fetch and save-discounts paths send `null`. This makes the confirmed request consistent with what was previewed.

## Change

`src/components/session/subscriptions/plan-preview.tsx` — `handleConfirmChangePlan`:
- `isUsageBasedProduct ? [] : ...` → `isUsageBasedProduct ? null : ...`
- `addons: addonsToSend` → `addons: addonsToSend && addonsToSend.length > 0 ? addonsToSend : null`

`ChangeSubscriptionPlanParams.data.addons` is typed `AddOn[] | null`, so `null` is type-safe.

## Behavior

- Usage-based updated product → `addons: null` (was `[]`)
- Subscription updated product with no addons selected → `addons: null`
- Subscription updated product with addons selected → unchanged (sends the filtered list)