### PR TITLE
feat(portal): show feature flag entitlement details

### DIFF
--- a/src/components/session/entitlements/entitlements-columns.tsx
+++ b/src/components/session/entitlements/entitlements-columns.tsx
@@ -45,6 +45,7 @@ const TYPE_LABELS: Record<string, string> = {
     framer: "Framer Template",
     digital_files: "Digital Product Delivery",
     license_key: "License Key",
+    feature_flag: "Feature Flag",
 };
 
 function statusBadgeVariant(status: PortalGrantResponse["status"]): BadgeVariant {
@@ -296,6 +297,7 @@ function GrantDetailSheet({
     const isLicenseKey = grant?.entitlement.integration_type === "license_key";
     const isDigitalFiles = grant?.entitlement.integration_type === "digital_files";
     const isFramer = grant?.entitlement.integration_type === "framer";
+    const isFeatureFlag = grant?.entitlement.integration_type === "feature_flag";
 
     const handleReconnect = async () => {
         if (!grant) return;
@@ -528,6 +530,15 @@ function GrantDetailSheet({
                                     )}
                                 </div>
                             )}
+                        </div>
+                    )}
+
+                    {isFeatureFlag && grant.entitlement.description && (
+                        <div className="space-y-2">
+                            <span className="text-sm text-text-secondary">Description</span>
+                            <p className="text-sm text-text-primary whitespace-pre-line">
+                                {grant.entitlement.description}
+                            </p>
                         </div>
                     )}
 


### PR DESCRIPTION
## What

Feature-flag entitlements now render properly in the customer portal.

## Changes

`src/components/session/entitlements/entitlements-columns.tsx`:
- Add `feature_flag: "Feature Flag"` to `TYPE_LABELS` — fixes the raw label in the **Type** column and the detail sheet header.
- Add a `feature_flag` branch in the grant detail sheet that shows the entitlement **Description** (if set). On/off state is already conveyed by the existing **Status** badge (Delivered/Revoked), and the table maps Delivered → active / Revoked → inactive.

Feature flags arrive via `PortalGrantResponse.entitlement` (`name`, `description`, `integration_type`). The portal response has no `feature`/`feature_id` object, so there's no key/artifact to show — name, description and status are the details.