### PR TITLE
feat(subscriptions): disable cancel action when business disallows cancellation

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -144,6 +144,7 @@
   "CancelSubscriptionSheet": {
     "triggerCancel": "Cancel Subscription",
     "triggerRevoke": "Revoke Cancellation",
+    "cancelDisabledTooltip": "Cancellation is disabled for this subscription. Please contact the merchant to cancel.",
     "sheetTitle": "We're sorry to see you go...",
     "currentPlan": "Current plan",
     "addOns": "{count, plural, one {# add-on} other {# add-ons}}",

--- a/src/app/session/subscriptions/[id]/page.tsx
+++ b/src/app/session/subscriptions/[id]/page.tsx
@@ -35,6 +35,7 @@ export default async function SubscriptionPage({
   const productCollection = await fetchProductCollectionByProductId(subscription.product.id);
   const business = await fetchBusiness();
   const canChangePlan = business?.allow_customer_portal_sub_change_plan ?? false;
+  const canCancel = business?.allow_customers_to_cancel_subscription ?? true;
   const allowMultipleSubscriptions = business?.allow_multiple_sub_per_customer ?? false;
 
   const invoiceParams = await extractPaginationParams(
@@ -62,6 +63,7 @@ export default async function SubscriptionPage({
       subscriptionId={id}
       productCollection={productCollection}
       canChangePlan={canChangePlan}
+      canCancel={canCancel}
       allowMultipleSubscriptions={allowMultipleSubscriptions}
     />
   );
@@ -107,12 +109,14 @@ function HeaderActions({
   subscriptionId,
   productCollection,
   canChangePlan,
+  canCancel,
   allowMultipleSubscriptions,
 }: {
   subscription: SubscriptionDetailsData;
   subscriptionId: string;
   productCollection: ProductCollectionData | null;
   canChangePlan: boolean;
+  canCancel: boolean;
   allowMultipleSubscriptions: boolean;
 }) {
   return (
@@ -132,6 +136,7 @@ function HeaderActions({
         <CancelSubscriptionSheet
           subscription={subscription}
           subscriptionId={subscriptionId}
+          disabled={!canCancel}
         />
       )}
     </>

--- a/src/components/session/cancel-subscription-sheet.tsx
+++ b/src/components/session/cancel-subscription-sheet.tsx
@@ -16,6 +16,12 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -52,11 +58,14 @@ const CANCELLATION_REASONS: { value: CancellationFeedback; label: string }[] =
 interface CancelSubscriptionSheetProps {
   subscription: SubscriptionDetailsData;
   subscriptionId: string;
+  /** Business disallows cancellation from the portal */
+  disabled?: boolean;
 }
 
 export function CancelSubscriptionSheet({
   subscription,
   subscriptionId,
+  disabled = false,
 }: CancelSubscriptionSheetProps) {
   const t = useTranslations("CancelSubscriptionSheet");
   const [open, setOpen] = useState(false);
@@ -124,6 +133,26 @@ export function CancelSubscriptionSheet({
     ),
     subscription.currency as CurrencyCode
   );
+
+  // A scheduled cancellation can still be revoked even when the business
+  // disallows new cancellations, so only the cancel trigger is blocked.
+  if (disabled && !subscription.cancel_at_next_billing_date) {
+    return (
+      <TooltipProvider>
+        <Tooltip delayDuration={100}>
+          <TooltipTrigger asChild>
+            {/* Disabled buttons don't emit pointer events; the span keeps the tooltip working */}
+            <span tabIndex={0}>
+              <Button variant="secondary" disabled>
+                {t("triggerCancel")}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{t("cancelDisabledTooltip")}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
 
   return (
     <Sheet

--- a/src/contexts/business-context.tsx
+++ b/src/contexts/business-context.tsx
@@ -13,6 +13,8 @@ export interface CustomerBusinessTrackingDetails {
 export interface Business {
     /** if null assume false */
     allow_customer_portal_sub_change_plan?: boolean | null;
+    /** if null assume true; when false the cancel subscription action is disabled */
+    allow_customers_to_cancel_subscription?: boolean | null;
     business_id: string;
     country?: null | string;
     description?: string | null;


### PR DESCRIPTION
## What

Respects the new `allow_customers_to_cancel_subscription` flag from `GET /customer-portal/business`. When the business turns cancellation off, the Cancel Subscription button is disabled with a tooltip asking the customer to contact the merchant (the cancel API also rejects with a 403 server-side).

## Changes

- `business-context.tsx`: add `allow_customers_to_cancel_subscription?: boolean | null` to the `Business` interface
- `subscriptions/[id]/page.tsx`: compute `canCancel` (defaults to true when the field is absent) and pass `disabled={!canCancel}` to the cancel sheet
- `cancel-subscription-sheet.tsx`: new `disabled` prop — renders a disabled trigger button wrapped in a tooltip instead of the sheet
- `messages/en.json`: new `cancelDisabledTooltip` string (other locales via the i18n pipeline)

## Behavior notes

- Defaults to allowing cancellation when the flag is missing, so nothing changes until the backend ships the field
- A subscription already scheduled for cancellation keeps its Revoke Cancellation action even when the flag is off, so customers can still choose to stay

## Testing

- `tsc --noEmit` passes
