### PR TITLE
fix(subscriptions): stop double-counting tax in the change-plan summary

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -204,7 +204,7 @@
     "tableTotal": "الإجمالي",
     "creditToBalance": "رصيد إلى الرصيد",
     "creditTooltip": "سيتم استخدام الرصيد لسداد المدفوعات المستقبلية",
-    "summaryTotal": "الإجمالي",
+    "summarySubtotal": "المجموع الفرعي",
     "summaryTax": "الضريبة",
     "summaryAmountDue": "المبلغ المستحق الآن",
     "payButton": "ادفع {amount}",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -204,7 +204,7 @@
     "tableTotal": "Total",
     "creditToBalance": "Crèdit al saldo",
     "creditTooltip": "El crèdit s’utilitzarà per pagar pagaments futurs",
-    "summaryTotal": "Total",
+    "summarySubtotal": "Subtotal",
     "summaryTax": "Impost",
     "summaryAmountDue": "Import a pagar ara",
     "payButton": "Paga {amount}",

--- a/messages/de.json
+++ b/messages/de.json
@@ -204,7 +204,7 @@
     "tableTotal": "Gesamt",
     "creditToBalance": "Gutschrift auf Guthaben",
     "creditTooltip": "Die Gutschrift wird zur Begleichung zukünftiger Zahlungen verwendet",
-    "summaryTotal": "Gesamt",
+    "summarySubtotal": "Zwischensumme",
     "summaryTax": "Steuern",
     "summaryAmountDue": "Jetzt fälliger Betrag",
     "payButton": "{amount} bezahlen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -205,7 +205,7 @@
     "tableTotal": "Total",
     "creditToBalance": "Credit to Balance",
     "creditTooltip": "Credit will be used to pay off future payments",
-    "summaryTotal": "Total",
+    "summarySubtotal": "Subtotal",
     "summaryTax": "Tax",
     "summaryAmountDue": "Amount due now",
     "payButton": "Pay {amount}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -204,7 +204,7 @@
     "tableTotal": "Total",
     "creditToBalance": "Crédito al saldo",
     "creditTooltip": "El crédito se usará para pagar futuros pagos",
-    "summaryTotal": "Total",
+    "summarySubtotal": "Subtotal",
     "summaryTax": "Impuestos",
     "summaryAmountDue": "Importe a pagar ahora",
     "payButton": "Pagar {amount}",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -204,7 +204,7 @@
     "tableTotal": "Total",
     "creditToBalance": "Crédit au solde",
     "creditTooltip": "Le crédit sera utilisé pour régler les paiements futurs",
-    "summaryTotal": "Total",
+    "summarySubtotal": "Sous-total",
     "summaryTax": "Taxe",
     "summaryAmountDue": "Montant dû maintenant",
     "payButton": "Payer {amount}",

--- a/messages/he.json
+++ b/messages/he.json
@@ -204,7 +204,7 @@
     "tableTotal": "סה״כ",
     "creditToBalance": "זיכוי ליתרה",
     "creditTooltip": "הזיכוי ישמש לתשלום תשלומים עתידיים",
-    "summaryTotal": "סה״כ",
+    "summarySubtotal": "סכום ביניים",
     "summaryTax": "מס",
     "summaryAmountDue": "סכום לתשלום כעת",
     "payButton": "תשלום {amount}",

--- a/messages/id.json
+++ b/messages/id.json
@@ -204,7 +204,7 @@
     "tableTotal": "Total",
     "creditToBalance": "Kredit ke Saldo",
     "creditTooltip": "Kredit akan digunakan untuk membayar pembayaran di masa mendatang",
-    "summaryTotal": "Total",
+    "summarySubtotal": "Subtotal",
     "summaryTax": "Pajak",
     "summaryAmountDue": "Jumlah yang harus dibayar sekarang",
     "payButton": "Bayar {amount}",

--- a/messages/it.json
+++ b/messages/it.json
@@ -204,7 +204,7 @@
     "tableTotal": "Totale",
     "creditToBalance": "Credito sul saldo",
     "creditTooltip": "Il credito verrà utilizzato per pagare i pagamenti futuri",
-    "summaryTotal": "Totale",
+    "summarySubtotal": "Subtotale",
     "summaryTax": "Imposta",
     "summaryAmountDue": "Importo dovuto ora",
     "payButton": "Paga {amount}",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -204,7 +204,7 @@
     "tableTotal": "合計",
     "creditToBalance": "残高へのクレジット",
     "creditTooltip": "クレジットは今後の支払いに充当されます",
-    "summaryTotal": "合計",
+    "summarySubtotal": "小計",
     "summaryTax": "税",
     "summaryAmountDue": "今回の支払い金額",
     "payButton": "{amount} を支払う",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -204,7 +204,7 @@
     "tableTotal": "합계",
     "creditToBalance": "잔액으로 크레딧",
     "creditTooltip": "크레딧은 향후 결제에 사용됩니다",
-    "summaryTotal": "합계",
+    "summarySubtotal": "소계",
     "summaryTax": "세금",
     "summaryAmountDue": "지금 결제할 금액",
     "payButton": "{amount} 결제",

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -204,7 +204,7 @@
     "tableTotal": "Jumlah",
     "creditToBalance": "Kredit ke Baki",
     "creditTooltip": "Kredit akan digunakan untuk membayar pembayaran pada masa hadapan",
-    "summaryTotal": "Jumlah",
+    "summarySubtotal": "Subjumlah",
     "summaryTax": "Cukai",
     "summaryAmountDue": "Jumlah perlu dibayar sekarang",
     "payButton": "Bayar {amount}",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -204,7 +204,7 @@
     "tableTotal": "Totaal",
     "creditToBalance": "Credit naar saldo",
     "creditTooltip": "Credit wordt gebruikt om toekomstige betalingen te voldoen",
-    "summaryTotal": "Totaal",
+    "summarySubtotal": "Subtotaal",
     "summaryTax": "Belasting",
     "summaryAmountDue": "Nu te betalen bedrag",
     "payButton": "Betaal {amount}",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -204,7 +204,7 @@
     "tableTotal": "Razem",
     "creditToBalance": "Uznanie salda",
     "creditTooltip": "Uznanie zostanie wykorzystane do rozliczenia przyszłych płatności",
-    "summaryTotal": "Razem",
+    "summarySubtotal": "Suma częściowa",
     "summaryTax": "Podatek",
     "summaryAmountDue": "Kwota do zapłaty teraz",
     "payButton": "Zapłać {amount}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -204,7 +204,7 @@
     "tableTotal": "Total",
     "creditToBalance": "Crédito para saldo",
     "creditTooltip": "O crédito será usado para pagar pagamentos futuros",
-    "summaryTotal": "Total",
+    "summarySubtotal": "Subtotal",
     "summaryTax": "Imposto",
     "summaryAmountDue": "Valor a pagar agora",
     "payButton": "Pagar {amount}",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -204,7 +204,7 @@
     "tableTotal": "Total",
     "creditToBalance": "Credit în sold",
     "creditTooltip": "Creditul va fi folosit pentru a acoperi plățile viitoare",
-    "summaryTotal": "Total",
+    "summarySubtotal": "Subtotal",
     "summaryTax": "Taxe",
     "summaryAmountDue": "Sumă de plată acum",
     "payButton": "Plătiți {amount}",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -204,7 +204,7 @@
     "tableTotal": "Итого",
     "creditToBalance": "Зачисление на баланс",
     "creditTooltip": "Кредит будет использован для оплаты будущих платежей",
-    "summaryTotal": "Итого",
+    "summarySubtotal": "Промежуточный итог",
     "summaryTax": "Налог",
     "summaryAmountDue": "К оплате сейчас",
     "payButton": "Оплатить {amount}",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -204,7 +204,7 @@
     "tableTotal": "Totalt",
     "creditToBalance": "Kredit till saldo",
     "creditTooltip": "Kredit kommer att användas för att betala framtida betalningar",
-    "summaryTotal": "Totalt",
+    "summarySubtotal": "Delsumma",
     "summaryTax": "Moms",
     "summaryAmountDue": "Att betala nu",
     "payButton": "Betala {amount}",

--- a/messages/th.json
+++ b/messages/th.json
@@ -204,7 +204,7 @@
     "tableTotal": "รวม",
     "creditToBalance": "เครดิตเข้ายอดคงเหลือ",
     "creditTooltip": "เครดิตจะถูกใช้เพื่อชำระการชำระเงินในอนาคต",
-    "summaryTotal": "รวม",
+    "summarySubtotal": "ยอดย่อย",
     "summaryTax": "ภาษี",
     "summaryAmountDue": "ยอดที่ต้องชำระตอนนี้",
     "payButton": "ชำระ {amount}",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -204,7 +204,7 @@
     "tableTotal": "Toplam",
     "creditToBalance": "Bakiyeye Kredi",
     "creditTooltip": "Kredi, gelecekteki ödemeleri karşılamak için kullanılacak",
-    "summaryTotal": "Toplam",
+    "summarySubtotal": "Ara Toplam",
     "summaryTax": "Vergi",
     "summaryAmountDue": "Şimdi ödenecek tutar",
     "payButton": "{amount} öde",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -204,7 +204,7 @@
     "tableTotal": "合计",
     "creditToBalance": "计入余额",
     "creditTooltip": "余额将用于支付未来的付款",
-    "summaryTotal": "合计",
+    "summarySubtotal": "小计",
     "summaryTax": "税费",
     "summaryAmountDue": "当前应付金额",
     "payButton": "支付 {amount}",

--- a/src/components/session/subscriptions/plan-preview.tsx
+++ b/src/components/session/subscriptions/plan-preview.tsx
@@ -321,13 +321,19 @@ function LineItemRow({
   // Tax = tax * proration_factor
   const displayTax = item.tax * (item.proration_factor ?? 1);
 
-  // Unit price = abs(unit_price * proration_factor)
-  const displayUnitPrice = Math.abs(item.unit_price * (item.proration_factor ?? 1));
+  // Unit price = abs(unit_price * proration_factor). `tax` is line-level while
+  // `unit_price` is per-unit (the backend divides the line price by quantity), so
+  // a tax-inclusive unit price has its own per-unit share of the tax baked in.
+  // Strip that out rather than zeroing the tax, so the Unit Price / Tax / Total
+  // columns still reconcile.
+  const perUnitTax = item.tax / (item.quantity || 1);
+  const preTaxUnitPrice = item.tax_inclusive
+    ? item.unit_price - perUnitTax
+    : item.unit_price;
+  const displayUnitPrice = Math.abs(preTaxUnitPrice * (item.proration_factor ?? 1));
 
-  // Calculate total: (unit_price * quantity) + tax. Tax-inclusive unit prices
-  // already contain the tax, so adding it again would overstate the line.
-  const lineTotal =
-    displayUnitPrice * displayQuantity + (item.tax_inclusive ? 0 : displayTax);
+  // Calculate total: (unit_price * quantity) + tax
+  const lineTotal = displayUnitPrice * displayQuantity + displayTax;
 
   return (
     <>
@@ -798,9 +804,17 @@ export function PlanPreview({
   // `settlement_amount` is already post-tax (the backend derives it from
   // `immediate_payment_post_tax_amount`), so the tax must be subtracted out for
   // the subtotal rather than added on for the total.
-  const hasSummary = Boolean(previewData && summary);
+  //
+  // It is also post-credit, while `settlement_tax` is the raw pre-credit tax.
+  // `customer_credits` is on the same basis and in the same currency (negative
+  // when credits were spent to offset the charge, positive when credits were
+  // added), so subtracting it reconstructs the pre-credit charge and keeps every
+  // row of the card on one basis: subtotal + tax + credits = amount due.
+  const hasSummary = Boolean(summary);
   const settlementAmount = summary?.settlement_amount || 0;
   const settlementTax = summary?.settlement_tax || 0;
+  const customerCredits = summary?.customer_credits || 0;
+  const preCreditAmount = settlementAmount - customerCredits;
 
   const formatSettlementAmount = (amount: number) => {
     if (!settlementCurrency) return "—";
@@ -1057,7 +1071,7 @@ export function PlanPreview({
                     {
                       label: t("summarySubtotal"),
                       value: hasSummary
-                        ? settlementAmount - settlementTax
+                        ? preCreditAmount - settlementTax
                         : null,
                       showSeparator: true,
                     },
@@ -1066,6 +1080,15 @@ export function PlanPreview({
                       value: hasSummary ? settlementTax : null,
                       showSeparator: true,
                     },
+                    ...(customerCredits !== 0
+                      ? [
+                        {
+                          label: t("creditToBalance"),
+                          value: customerCredits,
+                          showSeparator: true,
+                        },
+                      ]
+                      : []),
                     {
                       label: t("summaryAmountDue"),
                       value: hasSummary ? settlementAmount : null,

--- a/src/components/session/subscriptions/plan-preview.tsx
+++ b/src/components/session/subscriptions/plan-preview.tsx
@@ -271,7 +271,9 @@ function LineItemRow({
   if (item.type === "meter") {
     const meterTax = item.tax ?? 0;
     const meterSubtotal = item.subtotal ?? 0;
-    const meterTotal = meterSubtotal + meterTax;
+    // Tax-inclusive subtotals already contain the tax, so adding it again would
+    // overstate the line.
+    const meterTotal = meterSubtotal + (item.tax_inclusive ? 0 : meterTax);
 
     return (
       <>
@@ -322,8 +324,10 @@ function LineItemRow({
   // Unit price = abs(unit_price * proration_factor)
   const displayUnitPrice = Math.abs(item.unit_price * (item.proration_factor ?? 1));
 
-  // Calculate total: (unit_price * quantity) + tax
-  const lineTotal = displayUnitPrice * displayQuantity + displayTax;
+  // Calculate total: (unit_price * quantity) + tax. Tax-inclusive unit prices
+  // already contain the tax, so adding it again would overstate the line.
+  const lineTotal =
+    displayUnitPrice * displayQuantity + (item.tax_inclusive ? 0 : displayTax);
 
   return (
     <>
@@ -791,6 +795,13 @@ export function PlanPreview({
 
   const summary = previewData?.immediate_charge?.summary;
 
+  // `settlement_amount` is already post-tax (the backend derives it from
+  // `immediate_payment_post_tax_amount`), so the tax must be subtracted out for
+  // the subtotal rather than added on for the total.
+  const hasSummary = Boolean(previewData && summary);
+  const settlementAmount = summary?.settlement_amount || 0;
+  const settlementTax = summary?.settlement_tax || 0;
+
   const formatSettlementAmount = (amount: number) => {
     if (!settlementCurrency) return "—";
     return formatDecodedCurrency(amount, settlementCurrency);
@@ -1044,30 +1055,20 @@ export function PlanPreview({
                 <CardContent className="p-4 flex flex-col gap-0 bg-button-secondary-bg rounded-lg">
                   {[
                     {
-                      label: t("summaryTotal"),
-                      value:
-                        previewData && summary
-                          ? Math.abs(summary.settlement_amount || 0)
-                          : null,
+                      label: t("summarySubtotal"),
+                      value: hasSummary
+                        ? settlementAmount - settlementTax
+                        : null,
                       showSeparator: true,
                     },
                     {
                       label: t("summaryTax"),
-                      value:
-                        previewData && summary
-                          ? Math.abs(summary.settlement_tax || 0)
-                          : null,
+                      value: hasSummary ? settlementTax : null,
                       showSeparator: true,
                     },
                     {
                       label: t("summaryAmountDue"),
-                      value:
-                        previewData && summary
-                          ? Math.abs(
-                            (summary.settlement_amount || 0) +
-                            (summary.settlement_tax || 0)
-                          )
-                          : null,
+                      value: hasSummary ? settlementAmount : null,
                       isBold: true,
                       showSeparator: false,
                     },
@@ -1119,14 +1120,9 @@ export function PlanPreview({
               }
               loading={isConfirming}
             >
-              {previewData && summary
+              {hasSummary
                 ? t("payButton", {
-                  amount: formatSettlementAmount(
-                    Math.abs(
-                      (summary.settlement_amount || 0) +
-                      (summary.settlement_tax || 0)
-                    )
-                  ),
+                  amount: formatSettlementAmount(settlementAmount),
                 })
                 : t("confirmPlanChange")}
             </Button>


### PR DESCRIPTION
## Problem

On the change-plan flow, the summary card and the pay button both computed:

```
Amount due now = settlement_amount + settlement_tax
```

But `settlement_amount` is **already post-tax**. In the backend it maps to `calculations.immediate_payment_post_tax_amount` (`crates/public/src/routes/subscriptions.rs:8579`), and `process_tax` (`crates/public/src/routes/payments/payments_create.rs:3134-3153`) returns:

- tax-exclusive product → `price + tax`
- tax-inclusive product → `price` (tax already inside)

Either way the tax is baked in, so the customer saw an amount inflated by the full tax, including on the pay button CTA. The "Total" row was also mislabeled (it was the tax-inclusive total, not a pre-tax subtotal).

## Fix

Summary card now reads like a normal invoice:

| Row | Value |
| --- | --- |
| Subtotal | `settlement_amount - settlement_tax` |
| Tax | `settlement_tax` |
| **Amount due now** | `settlement_amount` |

The pay button now displays `settlement_amount`. The `Math.abs` wrappers are dropped: `settlement_amount` is clamped to `>= 0` by `settle_with_credits`, and the abs calls would have masked the sign on the subtotal.

### Also fixed (same class of bug)

Both branches of `LineItemRow` added tax to a price that may already contain it:

- Non-meter items: `unit_price` is the *input* to `process_tax` (`subscriptions.rs:8498`), so it is tax-inclusive for tax-inclusive products.
- Meter items: `subtotal` maps to `MeterCartDetail.price`, which is likewise the input to `process_tax` (`background_jobs/mod.rs:2153`).

Both now gate the `+ tax` on `!tax_inclusive`.

## Notes

- Replaces the now-unused `PlanPreview.summaryTotal` i18n key with `summarySubtotal` across all 21 locales.
- One edge case worth knowing: `settlement_amount` is post-credit (it goes through `settle_with_credits`) while `settlement_tax` is the raw pre-credit tax, so when wallet credits fully cover the charge the subtotal row can render negative. The credit itself already shows as a separate "Credit to balance" row in the line items table.
- `tsc --noEmit` clean.

Paired with the same fix in the dashboard frontend: dodopayments/frontend#678