### PR TITLE
chore(ci): add SonarQube analysis

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -1,15 +1,19 @@
 ---
 # SonarQube static analysis against https://sonarqube.dodopayments.com
 #
-# push-to-main ONLY, deliberately. SonarQube Community Build has no pull
-# request analysis (/api/project_pull_requests/list is not a registered
-# endpoint on 26.7.x), so a scan from ANY non-main ref is stored against the
-# MAIN branch and overwrites main's results with that ref's code.
+# push-to-main ONLY, deliberately. SonarQube Community Build analyses only the
+# main branch -- PR and branch analysis are Developer Edition features. With no
+# usable PR parameters the scanner attributes every analysis to MAIN, so a scan
+# from ANY non-main ref overwrites main's results with that ref's code and
+# silently corrupts main's quality history.
 #
-# The `if: github.ref` guard on the job is part of that same defence:
-# workflow_dispatch lets the dispatcher choose any ref, which would reopen the
-# exact hole the missing `pull_request:` trigger closes -- just via a different
-# door, and with no warning in the Actions UI that it is destructive.
+# Re-add `pull_request:` ONLY if this instance moves to Developer Edition. At
+# that point PR analysis becomes correct and this constraint no longer applies.
+#
+# The `if: github.ref` guard on the job is the other half of that defence:
+# workflow_dispatch lets the dispatcher choose any ref, reopening the same hole
+# through a different door, with no warning in the Actions UI that it is
+# destructive.
 #
 # No quality-gate step yet: this repo has no SonarQube baseline, and a blocking
 # gate on the first scan fails on pre-existing findings nobody has triaged.

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           # full history: SonarQube needs it for blame attribution and to
           # compute the new-code period

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -1,0 +1,43 @@
+---
+# SonarQube static analysis against https://sonarqube.dodopayments.com
+#
+# push-to-main ONLY, deliberately. SonarQube Community Build has no pull
+# request analysis (/api/project_pull_requests/list does not exist on this
+# build), so a scan triggered from a PR is stored against the MAIN branch and
+# overwrites main's results with the PR's code. Adding `pull_request:` here
+# would silently corrupt main's quality history.
+#
+# No quality-gate step yet: this repo has no SonarQube baseline, and a blocking
+# gate on first scan fails on pre-existing findings nobody has triaged. Enable
+# gating once a baseline exists and the "new code" period is meaningful.
+name: SonarQube Analysis
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonarqube-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sonarqube:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # full history: SonarQube uses it to attribute issues to authors
+          # and to compute the new-code period
+          fetch-depth: 0
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v7.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -2,14 +2,18 @@
 # SonarQube static analysis against https://sonarqube.dodopayments.com
 #
 # push-to-main ONLY, deliberately. SonarQube Community Build has no pull
-# request analysis (/api/project_pull_requests/list does not exist on this
-# build), so a scan triggered from a PR is stored against the MAIN branch and
-# overwrites main's results with the PR's code. Adding `pull_request:` here
-# would silently corrupt main's quality history.
+# request analysis (/api/project_pull_requests/list is not a registered
+# endpoint on 26.7.x), so a scan from ANY non-main ref is stored against the
+# MAIN branch and overwrites main's results with that ref's code.
+#
+# The `if: github.ref` guard on the job is part of that same defence:
+# workflow_dispatch lets the dispatcher choose any ref, which would reopen the
+# exact hole the missing `pull_request:` trigger closes -- just via a different
+# door, and with no warning in the Actions UI that it is destructive.
 #
 # No quality-gate step yet: this repo has no SonarQube baseline, and a blocking
-# gate on first scan fails on pre-existing findings nobody has triaged. Enable
-# gating once a baseline exists and the "new code" period is meaningful.
+# gate on the first scan fails on pre-existing findings nobody has triaged.
+# Enable gating once a baseline exists and the new-code period is meaningful.
 name: SonarQube Analysis
 
 on:
@@ -27,17 +31,24 @@ concurrency:
 jobs:
   sonarqube:
     name: SonarQube Scan
+    # Without this, a manual dispatch from a feature branch overwrites main's
+    # analysis. See the header comment.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          # full history: SonarQube uses it to attribute issues to authors
-          # and to compute the new-code period
+          # full history: SonarQube needs it for blame attribution and to
+          # compute the new-code period
           fetch-depth: 0
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v7.0.0
+        # Pinned to a commit SHA, not a tag: this step receives SONAR_TOKEN,
+        # so a retargeted or compromised release tag would hand credentials to
+        # replacement action code.
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=dodo-customer-portal
+sonar.projectName=dodo-customer-portal
+
+sonar.sources=.
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/.next/**,**/coverage/**,**/*.min.js

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,10 @@ sonar.projectKey=dodo-customer-portal
 sonar.projectName=dodo-customer-portal
 
 sonar.sources=.
-sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/.next/**,**/coverage/**,**/*.min.js
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/.next/**,**/out/**,**/coverage/**,**/*.min.js,**/*.snap,**/package-lock.json,**/pnpm-lock.yaml,**/yarn.lock,**/bun.lockb,**/*.generated.*,**/generated/**
+
+# Partition tests out of production source. Without this, test files inflate
+# ncloc and make the coverage ratio meaningless -- and fixing it later forces a
+# re-baseline, which defeats the point of landing this in report-only mode now.
+sonar.tests=.
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx,**/*.spec.ts,**/*.spec.tsx,**/*.spec.js,**/*.spec.jsx,**/__tests__/**,**/e2e/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,10 +2,12 @@ sonar.projectKey=dodo-customer-portal
 sonar.projectName=dodo-customer-portal
 
 sonar.sources=.
-sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/.next/**,**/out/**,**/coverage/**,**/*.min.js,**/*.snap,**/package-lock.json,**/pnpm-lock.yaml,**/yarn.lock,**/bun.lockb,**/*.generated.*,**/generated/**
-
-# Partition tests out of production source. Without this, test files inflate
-# ncloc and make the coverage ratio meaningless -- and fixing it later forces a
-# re-baseline, which defeats the point of landing this in report-only mode now.
 sonar.tests=.
+
+# The test patterns below appear in BOTH sonar.exclusions and
+# sonar.test.inclusions, deliberately. `sonar.sources=.` indexes them as MAIN
+# code, and sonar.test.inclusions alone does NOT remove them from the source
+# set -- so without the matching exclusions the scanner aborts the whole
+# analysis with "File ... can't be indexed twice".
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/.next/**,**/out/**,**/coverage/**,**/*.min.js,**/*.snap,**/package-lock.json,**/pnpm-lock.yaml,**/yarn.lock,**/bun.lockb,**/*.generated.*,**/generated/**,**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx,**/*.spec.ts,**/*.spec.tsx,**/*.spec.js,**/*.spec.jsx,**/__tests__/**,**/e2e/**
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx,**/*.spec.ts,**/*.spec.tsx,**/*.spec.js,**/*.spec.jsx,**/__tests__/**,**/e2e/**


### PR DESCRIPTION
Part of the org-wide SonarQube rollout. Scans on push to `main` against https://sonarqube.dodopayments.com. The SonarQube project and the `SONAR_TOKEN` / `SONAR_HOST_URL` repo secrets are already provisioned, so this is the last piece.

## Why `push` only, and no `pull_request:`

SonarQube **Community Build has no pull request analysis**. `/api/project_pull_requests/list` is not even a registered endpoint on `26.7.0.124771`, and the instance knows only the `main` branch. A PR-triggered scan is therefore stored **against main**, overwriting main's results with that PR's code.

`dodo-adapters` (the original workflow this is derived from) has that bug; it's being corrected separately. This workflow deliberately does not copy it.

## Why no quality-gate step

There's no baseline for this repo yet. A blocking gate on the very first scan fails on pre-existing, untriaged findings and would halt every PR here on day one. Analysis lands in report-only mode; gating gets switched on once a baseline exists and the new-code period is meaningful.

## Security

No `run:` steps and no interpolation of untrusted input, so there's no workflow-injection surface. `github.ref` appears only in a `concurrency` group, which is never shell-evaluated.

Excluded from analysis: `**/node_modules/**,**/dist/**,**/build/**,**/.next/**,**/coverage/**,**/*.min.js`
